### PR TITLE
update gh-action-pypi-publish to latest

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -120,7 +120,7 @@ jobs:
           path: dist
 
       - name: Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: ${{ secrets.pypi_test_password }}
@@ -130,7 +130,7 @@ jobs:
       - name: Upload to PyPI
         # upload to PyPI on every tag starting with 'v'
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: ${{ secrets.pypi_release_password }}


### PR DESCRIPTION
hey. I just noticed that you were pinning the pypi publish action to a commit SHA that increased the python version. [Their latest release seems to include](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.4.2) that now :) 