### PR TITLE
Add py.typed marker file for mypy compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,6 +244,7 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(where="src"),
     package_dir={"": "src"},
+    package_data={"pybase64": ["py.typed"]},
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.


### PR DESCRIPTION
This adds a py.typed marker file as per [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information)

Fixes #636 

At the same time, would it be better to narrow the type of input arg to the `b64encode` and `b64decode` functions? Currently they are `Any` but they could be a `Union[str, bytes]` or similar?