### PR TITLE
chore(ci): run `nox -s test` with all interpreters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - uses: wntrblm/nox@2022.11.21
+      with:
+        python-versions: "3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy3.8, pypy3.9, pypy3.10"
+    - name: "Allow nox to run with python 3.6"
+      run: pipx runpip nox install 'virtualenv<20.22.0'
+    - name: "Run tests"
+      run: nox --error-on-missing-interpreters -s test


### PR DESCRIPTION
This allows to test the fallback implementation with all interpreters