### PR TITLE
chore: drop python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,13 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: wntrblm/nox@2022.11.21
+    - uses: wntrblm/nox@2023.04.22
       with:
-        python-versions: "3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy3.8, pypy3.9, pypy3.10"
-    - name: "Allow nox to run with python 3.6"
-      run: pipx runpip nox install 'virtualenv<20.22.0'
+        python-versions: "3.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy3.8, pypy3.9, pypy3.10"
     - name: "Run tests"
       run: nox --error-on-missing-interpreters -s test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   rev: v3.15.0
   hooks:
   - id: pyupgrade
-    args: ["--py36-plus"]
+    args: ["--py37-plus"]
 
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.12.1
@@ -34,6 +34,7 @@ repos:
   rev: 5.13.2
   hooks:
   - id: isort
+    args: ["-a", "from __future__ import annotations"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.8.0

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,10 @@ Running Python 3.7.2, Apple LLVM version 10.0.0 (clang-1000.11.45.5), Mac OS X 1
 
 Changelog
 =========
+Future
+------
+- Drop python 3.6 support
+
 1.3.2
 -----
 - Update base64 library

--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,5 @@
+from __future__ import annotations
+
+
 def pytest_addoption(parser) -> None:
     parser.addoption("--sde-cpu", action="store", default=None, help="run sde tests")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import annotations
+
 import datetime
 import os
 import runpy

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
-from typing import Dict
 
 import nox
 
@@ -9,7 +10,7 @@ HERE = Path(__file__).resolve().parent
 
 nox.options.sessions = ["lint", "test"]
 
-ALL_CPYTHON = [f"3.{minor}" for minor in range(6, 12 + 1)]
+ALL_CPYTHON = [f"3.{minor}" for minor in range(7, 12 + 1)]
 ALL_PYPY = [f"pypy3.{minor}" for minor in range(8, 10 + 1)]
 ALL_PYTHON = ALL_CPYTHON + ALL_PYPY
 
@@ -21,7 +22,7 @@ def lint(session: nox.Session) -> None:
     session.run("pre-commit", "run", "-a")
 
 
-def update_env_macos(session: nox.Session, env: Dict[str, str]) -> None:
+def update_env_macos(session: nox.Session, env: dict[str, str]) -> None:
     if sys.platform.startswith("darwin"):
         # we don't support universal builds
         machine = session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-verbosity = 1
 profile = "black"
 
 [tool.mypy]
-python_version = 3.6
+python_version = "3.7"
 follow_imports = "silent"
 ignore_missing_imports = true
 disallow_untyped_defs = true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,1 @@
-pytest==7.0.1 ; python_version == '3.6'
-pytest==7.4.3 ; python_version >= '3.7'
+pytest==7.4.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import sys
 
-if sys.version_info[:2] < (3, 6):
-    raise RuntimeError("Python version >= 3.6 required.")
+if sys.version_info[:2] < (3, 7):
+    raise RuntimeError("Python version >= 3.7 required.")
 
 import logging
 import os
@@ -228,7 +230,6 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: C",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -237,7 +238,7 @@ setup(
         "Programming Language :: Python :: 3.12",
     ],
     # Supported python versions
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     # What does your project relate to?
     keywords="base64",
     # You can just specify the packages manually here if your project is

--- a/src/pybase64/__init__.py
+++ b/src/pybase64/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from ._license import _license

--- a/src/pybase64/__main__.py
+++ b/src/pybase64/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import base64
 import sys

--- a/src/pybase64/_fallback.py
+++ b/src/pybase64/_fallback.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from base64 import b64decode as builtin_decode
 from base64 import b64encode as builtin_encode
 from base64 import encodebytes as builtin_encodebytes
 from binascii import Error as BinAsciiError
-from typing import Any, Union
+from typing import Any
 
 __all__ = [
     "_get_simd_name",
@@ -26,7 +28,7 @@ def _get_simd_path() -> int:
     return 0
 
 
-def _get_bytes(s: Any) -> Union[bytes, bytearray]:
+def _get_bytes(s: Any) -> bytes | bytearray:
     if isinstance(s, str):
         try:
             return s.encode("ascii")

--- a/src/pybase64/_version.py
+++ b/src/pybase64/_version.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 __version__ = "1.3.2"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import os
 from base64 import encodebytes as b64encodebytes


### PR DESCRIPTION
Time to drop Python 3.6 support.

`pypinfo -l 25 --percent 'pybase64==1.3.*' pyversion`

| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 3.10           |  62.12% |        336,171 |
| 3.9            |  12.38% |         67,003 |
| 3.8            |  12.05% |         65,224 |
| 3.11           |   8.05% |         43,543 |
| 3.7            |   2.95% |         15,954 |
| 3.12           |   2.12% |         11,481 |
| 3.6            |   0.31% |          1,697 |
| 3.3            |   0.01% |             50 |
| 3.4            |   0.00% |              4 |
| 2.7            |   0.00% |              3 |
| 3.13           |   0.00% |              2 |
| Total          |         |        541,132 |