### PR TITLE
chore: test with python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,6 @@ jobs:
         submodules: recursive
     - uses: wntrblm/nox@2024.10.09
       with:
-        python-versions: "3.8, 3.9, 3.10, 3.11, 3.12, pypy3.9, pypy3.10"
+        python-versions: "3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy3.9, pypy3.10"
     - name: "Run tests"
       run: nox --error-on-missing-interpreters -s test

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ HERE = Path(__file__).resolve().parent
 
 nox.options.sessions = ["lint", "test"]
 
-ALL_CPYTHON = [f"3.{minor}" for minor in range(8, 12 + 1)]
+ALL_CPYTHON = [f"3.{minor}" for minor in range(8, 13 + 1)]
 ALL_PYPY = [f"pypy3.{minor}" for minor in range(9, 10 + 1)]
 ALL_PYTHON = ALL_CPYTHON + ALL_PYPY
 


### PR DESCRIPTION
Only binary wheels were tested, this allows to test the fallback as well.