### PR TITLE
Add iOS support

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -25,25 +25,38 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   build_wheels:
-    name: Build ${{ matrix.archs }} ${{ matrix.build }} wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.archs }} ${{ matrix.build }} wheels on ${{ matrix.platform }}
     needs: [lint]
-    runs-on: "${{ matrix.os }}${{ startsWith(matrix.archs, 'aarch64') && '-arm' || '' }}"
+    runs-on: "${{ matrix.runs-on }}${{ startsWith(matrix.archs, 'aarch64') && '-arm' || '' }}"
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        platform: [linux]
         archs: ["x86_64, i686", "aarch64, armv7l", "ppc64le", "s390x"]
         build: ["manylinux", "musllinux"]
         include:
-          - os: windows-2019
+          - runs-on: ubuntu-24.04
+
+          - platform: "windows"
+            runs-on: windows-2019
             archs: "AMD64"
-          - os: windows-2019
+          - platform: "windows"
+            runs-on: windows-2019
             archs: "x86"
-          - os: windows-2019
+          - platform: "windows"
+            runs-on: windows-2019
             archs: "ARM64"
-          - os: macos-13
+          - platform: "macos"
+            runs-on: macos-13
             archs: "x86_64"
-          - os: macos-14
+          - platform: "macos"
+            runs-on: macos-14
             archs: "arm64"
+          - platform: "ios"
+            runs-on: macos-13
+            archs: "x86_64_iphonesimulator"
+          - platform: "ios"
+            runs-on: macos-latest
+            archs: "arm64_iphonesimulator,arm64_iphoneos"
 
     steps:
       - name: Set git to use LF
@@ -71,13 +84,14 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0
         env:
+          CIBW_PLATFORM: "${{ matrix.platform }}"
           CIBW_ARCHS: "${{ matrix.archs }}"
           CIBW_BUILD: "${{ matrix.build && '*-' || ''}}${{ matrix.build }}*"
           CIBW_ENABLE: "${{ startsWith(github.ref, 'refs/tags/v') && '' || 'cpython-prerelease'}}"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: "cibw-wheels ${{ matrix.build || matrix.os }} ${{ matrix.archs }}"
+          name: "cibw-wheels ${{ matrix.build || matrix.platform }} ${{ matrix.archs }}"
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -82,7 +82,7 @@ jobs:
           python-version: 3.8
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_PLATFORM: "${{ matrix.platform }}"
           CIBW_ARCHS: "${{ matrix.archs }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,12 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 enable = ["cpython-freethreading", "pypy"]
 test-requires = "-r requirements-test.txt"
-test-command = "pytest {project}/tests"
+test-command = "pytest tests"
 test-skip = "*-win_arm64"  # silence warnings for windows ARM64
+test-sources = [
+  "tests",
+]
+safe-tools = ["cmake"]
 build-verbosity = 1
 manylinux-i686-image = "manylinux2014"
 manylinux-pypy_i686-image = "manylinux2014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 enable = ["cpython-freethreading", "pypy"]
 test-requires = "-r requirements-test.txt"
-test-command = "pytest tests"
+test-command = "pytest tests -vv"
 test-skip = "*-win_arm64"  # silence warnings for windows ARM64
 test-sources = [
   "tests",

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,24 @@ def get_cmake_extra_config(plat_name: str | None, build_type: str) -> tuple[bool
             extra_config.append(f"-DCMAKE_OSX_ARCHITECTURES={arch}")
         else:
             log.warning("`%s` is not a known value for CMAKE_OSX_ARCHITECTURES", arch)
+    elif sys.platform == "ios":
+        if platform_module.ios_ver().is_simulator:
+            sdk = "iphonesimulator"
+        else:
+            sdk = "iphoneos"
+        sysroot = subprocess.check_output(
+            ["xcrun", "--show-sdk-path", "--sdk", sdk]
+        ).strip().decode("latin1")
+        arch = "x86_64" if platform_module.machine() == "x86_64" else "aarch64"
+        ios_min_ver = os.getenv("IPHONEOS_DEPLOYMENT_TARGET", "13.0")
 
+        extra_config.extend([
+            "-DCMAKE_SYSTEM_NAME=iOS",
+            f"-DCMAKE_SYSTEM_PROCESSOR={arch}",
+            f"-DCMAKE_OSX_DEPLOYMENT_TARGET={ios_min_ver}",
+            f"-DCMAKE_OSX_SYSROOT={sysroot}",
+            "-DBUILD_SHARED_LIBS=NO",
+        ])
     return is_msvc, extra_config
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -138,6 +138,10 @@ def test_decode(
     assert captured.out == b"hello world !/?\n"
 
 
+@pytest.mark.skipif(
+    sys.platform == "ios",
+    reason="Subprocess tests don't work on iOS",
+)
 def test_subprocess() -> None:
     import subprocess
 


### PR DESCRIPTION
Adds configuration changes to support building iOS wheels.

While working on iOS packaging in cibuildwheel, I've been using pybase64 as an example of a simple binary package with a CMake build system. I figured I might as well contribute the changes needed to support iOS upstream.

This requires the in-development changes from pypa/cibuildwheel#2317. Assuming that PR is accepted, those changes won't become available any earlier than cibuildwheel 3.0. This PR presumptively bumps the cibuildwheel reference in the build-upload workflow to use that (as yet unreleased) version. 