### PR TITLE
break: use ValueError for altchars length validation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,7 @@ Changelog
 Future
 ------
 - Speed-up translation on aarch64
+- Use ``ValueError`` instead of ``AssertionError`` on altchars length validation
 - Add SBOM to PyPI wheels
 - Add initial support for Python 3.15
 

--- a/src/pybase64/_fallback.py
+++ b/src/pybase64/_fallback.py
@@ -7,9 +7,11 @@ from binascii import Error as BinAsciiError
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Final
+
     from ._typing import Buffer
 
-_bytes_types = (bytes, bytearray)  # Types acceptable as binary data
+_BYTES_TYPES: Final = (bytes, bytearray)  # Types acceptable as binary data
 
 
 def _get_simd_name(flags: int) -> str:
@@ -28,7 +30,7 @@ def _get_bytes(s: str | Buffer) -> bytes | bytearray:
         except UnicodeEncodeError:
             msg = "string argument should contain only ASCII characters"
             raise ValueError(msg) from None
-    if isinstance(s, _bytes_types):
+    if isinstance(s, _BYTES_TYPES):
         return s
     try:
         mv = memoryview(s)
@@ -42,6 +44,12 @@ def _get_bytes(s: str | Buffer) -> bytes | bytearray:
             f"string, not {s.__class__.__name__!r:s}"
         )
         raise TypeError(msg) from None
+
+
+def _validate_altchars(altchars: bytes | bytearray) -> None:
+    if len(altchars) != 2:
+        msg = "len(altchars) != 2"
+        raise ValueError(msg) from None
 
 
 def b64decode(
@@ -71,6 +79,7 @@ def b64decode(
     s = _get_bytes(s)
     if altchars is not None:
         altchars = _get_bytes(altchars)
+        _validate_altchars(altchars)
     if validate:
         if len(s) % 4 != 0:
             msg = "Incorrect padding"
@@ -138,6 +147,7 @@ def b64encode(s: Buffer, altchars: str | Buffer | None = None) -> bytes:
         raise BufferError(msg)
     if altchars is not None:
         altchars = _get_bytes(altchars)
+        _validate_altchars(altchars)
     return builtin_encode(s, altchars)
 
 

--- a/src/pybase64/_pybase64.c
+++ b/src/pybase64/_pybase64.c
@@ -85,7 +85,7 @@ static int parse_alphabet(PyObject* alphabetObject, char* alphabet, int* useAlph
     if (buffer.len != 2) {
         PyBuffer_Release(&buffer);
         Py_DECREF(alphabetObject);
-        PyErr_SetString(PyExc_AssertionError, "len(altchars) != 2");
+        PyErr_SetString(PyExc_ValueError, "len(altchars) != 2");
         return -1;
     }
 

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -96,9 +96,11 @@ for altchars in altchars_lut:
     test_vectors_b64.append([vector.translate(trans) for vector in test_vectors_b64_list])
 
 test_vectors_bin = []
-for altchars in altchars_lut:
+for altchars_id in AltCharsId:
+    altchars = altchars_lut[altchars_id]
+    vectors = test_vectors_b64[altchars_id]
     test_vectors_bin.append(
-        [base64.b64decode(vector, altchars) for vector in test_vectors_b64_list],
+        [base64.b64decode(vector, altchars) for vector in vectors],
     )
 
 
@@ -307,9 +309,9 @@ def test_invalid_padding_dec(
 
 
 params_invalid_altchars_values = [
-    [b"", (AssertionError, ValueError)],  # Python 3.15+ uses ValueError for decoding
-    [b"-", (AssertionError, ValueError)],  # Python 3.15+ uses ValueError for decoding
-    [b"-__", (AssertionError, ValueError)],  # Python 3.15+ uses ValueError for decoding
+    [b"", ValueError],
+    [b"-", ValueError],
+    [b"-__", ValueError],
     [3.0, TypeError],
     ["-€", ValueError],
     [memoryview(b"- _")[::2], BufferError],


### PR DESCRIPTION
While strictly speaking, this is a breaking change, it's unlikely this will cause any issues downstream.
CPython used to use a simple `assert` statement which was likely enough to catch errors for this argument which is likely hardcoded almost everywhere at some point.
pybase64 was relying on Python to do this argument check in the fallback implementation and used an `AssertionError` in the C-extension.
CPython moved to a `ValueError` in Python 3.15, at least for decoding.
Let's use a consistent check raising a `ValueError` in every case.