### PR TITLE
chore: do not import typing except when running type checkers

### DIFF
--- a/src/pybase64/__init__.py
+++ b/src/pybase64/__init__.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from ._license import _license
 from ._version import _version
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from ._typing import Buffer
 

--- a/src/pybase64/__main__.py
+++ b/src/pybase64/__main__.py
@@ -7,12 +7,13 @@ from base64 import b64decode as b64decode_validate
 from base64 import encodebytes as b64encodebytes
 from pathlib import Path
 from timeit import default_timer as timer
-from typing import TYPE_CHECKING, Any
 
 import pybase64
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Any
 
     from pybase64._typing import Buffer, Decode, Encode, EncodeBytes
 

--- a/src/pybase64/_fallback.py
+++ b/src/pybase64/_fallback.py
@@ -5,8 +5,8 @@ from base64 import b64decode as builtin_decode
 from base64 import b64encode as builtin_encode
 from base64 import encodebytes as builtin_encodebytes
 from binascii import Error as BinAsciiError
-from typing import TYPE_CHECKING
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import Final
 


### PR DESCRIPTION
Type checkers should always consider `TYPE_CHECKING` to be `True`.
This is the case for at least MyPy.
This lowers pybase64 import time at runtime.