### PR TITLE
fix: reject non-ASCII strings in `b64decode` when `validate=False`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,8 @@ Future
 - Add SBOM to PyPI wheels
 - Add initial support for Python 3.15
 - Deprecate accepting the ``+`` and ``/`` characters with an alternative alphabet when decoding
-- Add ``wrapcol`` parameter to b64encode
+- Add ``wrapcol`` parameter to ``b64encode``
+- Reject non-ASCII strings in ``b64decode`` when ``validate=False``
 
 1.4.3
 -----

--- a/src/pybase64/_pybase64.c
+++ b/src/pybase64/_pybase64.c
@@ -24,10 +24,6 @@
 #define PYBASE64_FLAGS_ENCODE_AS_STRING (1U << 0)
 #define PYBASE64_FLAGS_APPEND_NEW_LINE  (1U << 1)
 
-#define PYBASE64_SUCCESS 0
-#define PYBASE64_INVALID_PADDING 1
-#define PYBASE64_NOT_ASCII 2
-
 typedef struct pybase64_state {
     PyObject *binAsciiError;
     uint32_t active_simd_flag;
@@ -326,9 +322,6 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
             uint8_t c = *src++; srclen--;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                if (c >= 128U) {
-                    return PYBASE64_NOT_ASCII;
-                }
                 continue;
             }
             carry = q << 2;
@@ -337,14 +330,11 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return PYBASE64_INVALID_PADDING;
+                return 1;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                if (c >= 128U) {
-                    return PYBASE64_NOT_ASCII;
-                }
                 continue;
             }
             *out++ = carry | (q >> 4);
@@ -355,14 +345,11 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return PYBASE64_INVALID_PADDING;
+                return 1;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                if (c >= 128U) {
-                    return PYBASE64_NOT_ASCII;
-                }
                 if (q == 254) {
                     /* if the next valid byte is '=' => end */
                     if (next_valid_padding(src, srclen) == 254) {
@@ -379,14 +366,11 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return PYBASE64_INVALID_PADDING;
+                return 1;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                if (c >= 128U) {
-                    return PYBASE64_NOT_ASCII;
-                }
                 if (q == 254) {
                     srclen = 0U;
                     break;
@@ -399,7 +383,7 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
     }
 END:
     *outlen = out - out_start;
-    return PYBASE64_SUCCESS;
+    return 0;
 }
 
 static PyObject* pybase64_encode_impl_core(PyObject* self, Py_buffer const* buffer, char const* alphabet, Py_ssize_t wrapcol, unsigned int flags)
@@ -640,7 +624,7 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
     }
 
     if (PyUnicode_Check(in_object)) {
-        if ((PyUnicode_READY(in_object) == 0) && (PyUnicode_KIND(in_object) == PyUnicode_1BYTE_KIND)) {
+        if (validation && (PyUnicode_READY(in_object) == 0) && (PyUnicode_KIND(in_object) == PyUnicode_1BYTE_KIND)) {
             source = PyUnicode_1BYTE_DATA(in_object);
             source_len = PyUnicode_GET_LENGTH(in_object);
         }
@@ -755,15 +739,7 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         Py_END_ALLOW_THREADS
 
         if (result != 0) {
-            switch (result)
-            {
-            case PYBASE64_INVALID_PADDING:
-                PyErr_SetString(state->binAsciiError, "Incorrect padding");
-                break;
-            case PYBASE64_NOT_ASCII:
-                PyErr_SetString(PyExc_ValueError, "string argument should contain only ASCII characters");
-                break;
-            }
+            PyErr_SetString(state->binAsciiError, "Incorrect padding");
             goto EXCEPT;
         }
     }

--- a/src/pybase64/_pybase64.c
+++ b/src/pybase64/_pybase64.c
@@ -24,6 +24,10 @@
 #define PYBASE64_FLAGS_ENCODE_AS_STRING (1U << 0)
 #define PYBASE64_FLAGS_APPEND_NEW_LINE  (1U << 1)
 
+#define PYBASE64_SUCCESS 0
+#define PYBASE64_INVALID_PADDING 1
+#define PYBASE64_NOT_ASCII 2
+
 typedef struct pybase64_state {
     PyObject *binAsciiError;
     uint32_t active_simd_flag;
@@ -322,6 +326,9 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
             uint8_t c = *src++; srclen--;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
+                if (c >= 128U) {
+                    return PYBASE64_NOT_ASCII;
+                }
                 continue;
             }
             carry = q << 2;
@@ -330,11 +337,14 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return 1;
+                return PYBASE64_INVALID_PADDING;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
+                if (c >= 128U) {
+                    return PYBASE64_NOT_ASCII;
+                }
                 continue;
             }
             *out++ = carry | (q >> 4);
@@ -345,11 +355,14 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return 1;
+                return PYBASE64_INVALID_PADDING;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
+                if (c >= 128U) {
+                    return PYBASE64_NOT_ASCII;
+                }
                 if (q == 254) {
                     /* if the next valid byte is '=' => end */
                     if (next_valid_padding(src, srclen) == 254) {
@@ -366,11 +379,14 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return 1;
+                return PYBASE64_INVALID_PADDING;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
+                if (c >= 128U) {
+                    return PYBASE64_NOT_ASCII;
+                }
                 if (q == 254) {
                     srclen = 0U;
                     break;
@@ -383,7 +399,7 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
     }
 END:
     *outlen = out - out_start;
-    return 0;
+    return PYBASE64_SUCCESS;
 }
 
 static PyObject* pybase64_encode_impl_core(PyObject* self, Py_buffer const* buffer, char const* alphabet, Py_ssize_t wrapcol, unsigned int flags)
@@ -739,7 +755,15 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         Py_END_ALLOW_THREADS
 
         if (result != 0) {
-            PyErr_SetString(state->binAsciiError, "Incorrect padding");
+            switch (result)
+            {
+            case PYBASE64_INVALID_PADDING:
+                PyErr_SetString(state->binAsciiError, "Incorrect padding");
+                break;
+            case PYBASE64_NOT_ASCII:
+                PyErr_SetString(PyExc_ValueError, "string argument should contain only ASCII characters");
+                break;
+            }
             goto EXCEPT;
         }
     }

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -372,19 +372,13 @@ def test_invalid_altchars_dec_validate(
 
 
 params_invalid_data_novalidate_values = [
-    [
-        b"A@@@@FG",
-        None,
-        BinAsciiError,
-        "Incorrect padding|Non-base64 digit found|Only base64 data is allowed",
-    ],
+    [b"A@@@@FG", None, BinAsciiError, "Incorrect padding|Non-base64 digit found|Only base64 data"],
     ["ABC€", None, ValueError, "ASCII"],
     [3.0, None, TypeError, "bytes-like|buffer interface"],
     [memoryview(b"ABCDEFGH")[::2], None, BufferError, "contiguous"],
-    ["\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
-    ["a\x80aa", None, ValueError, "ASCII|Non-base64 digit found"],
-    ["aa\x80a", None, ValueError, "ASCII|Non-base64 digit found"],
-    ["aaa\x80", None, ValueError, "ASCII|Non-base64 digit found"],
+    ["a\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
+    ["a\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
+    [b"a\x80aa", None, BinAsciiError, "Incorrect padding|Non-base64 digit found|Only base64 data"],
 ]
 params_invalid_data_validate_values = [
     [b"\x00\x00\x00\x00", None, BinAsciiError, None],
@@ -394,6 +388,7 @@ params_invalid_data_validate_values = [
     [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcde@=", b"-_", BinAsciiError, None],
     [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcd@==", b"-_", BinAsciiError, None],
     [b"A@@@@FGH" * 10000, b"-_", BinAsciiError, None],
+    [b"a\x80aaa", None, BinAsciiError, "Incorrect padding|Non-base64 digit found|Only base64 data"],
 ]
 params_invalid_data_all = pytest.mark.parametrize(
     ("vector", "altchars", "exception", "match"),

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -376,9 +376,9 @@ params_invalid_data_novalidate_values = [
     ["ABC€", None, ValueError, "ASCII"],
     [3.0, None, TypeError, "bytes-like|buffer interface"],
     [memoryview(b"ABCDEFGH")[::2], None, BufferError, "contiguous"],
-    ["a\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
-    ["a\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
+    ["a\x80aa", None, ValueError, "ASCII|Non-base64 digit found"],
     [b"a\x80aa", None, BinAsciiError, "Incorrect padding|Non-base64 digit found|Only base64 data"],
+    ["a\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
 ]
 params_invalid_data_validate_values = [
     [b"\x00\x00\x00\x00", None, BinAsciiError, None],

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -372,22 +372,31 @@ def test_invalid_altchars_dec_validate(
 
 
 params_invalid_data_novalidate_values = [
-    [b"A@@@@FG", None, BinAsciiError],
-    ["ABC€", None, ValueError],
-    [3.0, None, TypeError],
-    [memoryview(b"ABCDEFGH")[::2], None, BufferError],
+    [
+        b"A@@@@FG",
+        None,
+        BinAsciiError,
+        "Incorrect padding|Non-base64 digit found|Only base64 data is allowed",
+    ],
+    ["ABC€", None, ValueError, "ASCII"],
+    [3.0, None, TypeError, "bytes-like|buffer interface"],
+    [memoryview(b"ABCDEFGH")[::2], None, BufferError, "contiguous"],
+    ["\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
+    ["a\x80aa", None, ValueError, "ASCII|Non-base64 digit found"],
+    ["aa\x80a", None, ValueError, "ASCII|Non-base64 digit found"],
+    ["aaa\x80", None, ValueError, "ASCII|Non-base64 digit found"],
 ]
 params_invalid_data_validate_values = [
-    [b"\x00\x00\x00\x00", None, BinAsciiError],
-    [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcdef", b"-_", BinAsciiError],
-    [b"A@@@=FGHIJKLMNOPQRSTUVWXYZabcdef", b"-_", BinAsciiError],
-    [b"A@@=@FGHIJKLMNOPQRSTUVWXYZabcdef", b"-_", BinAsciiError],
-    [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcde@=", b"-_", BinAsciiError],
-    [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcd@==", b"-_", BinAsciiError],
-    [b"A@@@@FGH" * 10000, b"-_", BinAsciiError],
+    [b"\x00\x00\x00\x00", None, BinAsciiError, None],
+    [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcdef", b"-_", BinAsciiError, None],
+    [b"A@@@=FGHIJKLMNOPQRSTUVWXYZabcdef", b"-_", BinAsciiError, None],
+    [b"A@@=@FGHIJKLMNOPQRSTUVWXYZabcdef", b"-_", BinAsciiError, None],
+    [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcde@=", b"-_", BinAsciiError, None],
+    [b"A@@@@FGHIJKLMNOPQRSTUVWXYZabcd@==", b"-_", BinAsciiError, None],
+    [b"A@@@@FGH" * 10000, b"-_", BinAsciiError, None],
 ]
 params_invalid_data_all = pytest.mark.parametrize(
-    ("vector", "altchars", "exception"),
+    ("vector", "altchars", "exception", "match"),
     params_invalid_data_novalidate_values + params_invalid_data_validate_values,
     ids=[
         str(i)
@@ -397,12 +406,12 @@ params_invalid_data_all = pytest.mark.parametrize(
     ],
 )
 params_invalid_data_novalidate = pytest.mark.parametrize(
-    ("vector", "altchars", "exception"),
+    ("vector", "altchars", "exception", "match"),
     params_invalid_data_novalidate_values,
     ids=[str(i) for i in range(len(params_invalid_data_novalidate_values))],
 )
 params_invalid_data_validate = pytest.mark.parametrize(
-    ("vector", "altchars", "exception"),
+    ("vector", "altchars", "exception", "match"),
     params_invalid_data_validate_values,
     ids=[str(i) for i in range(len(params_invalid_data_validate_values))],
 )
@@ -416,10 +425,11 @@ def test_invalid_data_dec(
     vector: Any,
     altchars: Buffer | None,
     exception: type[BaseException],
+    match: str | None,
     simd: int,
 ) -> None:
     utils.unused_args(simd)  # simd is a parameter in order to control the order of tests
-    with pytest.raises(exception):
+    with pytest.raises(exception, match=match):
         dfn(vector, altchars)
 
 
@@ -431,9 +441,14 @@ def test_invalid_data_dec_skip(
     vector: Any,
     altchars: Buffer | None,
     exception: type[BaseException],
+    match: str | None,
     simd: int,
 ) -> None:
-    utils.unused_args(exception, simd)  # simd is a parameter in order to control the order of tests
+    utils.unused_args(
+        exception,
+        match,
+        simd,
+    )  # simd is a parameter in order to control the order of tests
     test = dfn(vector, altchars)
     if sys.implementation.name == "graalpy" and vector.startswith((b"A@@@=F", b"A@@=@")):
         pytest.xfail(reason="graalpy fails decoding those entries")  # pragma: no cover
@@ -449,10 +464,11 @@ def test_invalid_data_dec_validate(
     vector: Any,
     altchars: Buffer | None,
     exception: type[BaseException],
+    match: str | None,
     simd: int,
 ) -> None:
     utils.unused_args(simd)  # simd is a parameter in order to control the order of tests
-    with pytest.raises(exception):
+    with pytest.raises(exception, match=match):
         dfn(vector, altchars, validate=True)
 
 


### PR DESCRIPTION
Align with documentation and Python behavior with the expectation that non-ASCII `str` inputs are rejected.