### PR TITLE
feat: Add `ignorechars` parameter to b64decode

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2017-2025, Matthieu Darbois
+Copyright (c) 2017-2026, Matthieu Darbois
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,7 @@ Future
 - Drop python 3.8 support
 - Stop publishing python 3.13t wheels
 - Add ``ignorechars`` parameter to ``b64decode``
+- Handle excess padding with the same behavior as CPython 3.15
 
 1.4.3
 -----

--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ Future
 - Reject non-ASCII strings in ``b64decode`` when ``validate=False``
 - Drop python 3.8 support
 - Stop publishing python 3.13t wheels
+- Add ``ignorechars`` parameter to ``b64decode``
 
 1.4.3
 -----

--- a/src/pybase64/__main__.py
+++ b/src/pybase64/__main__.py
@@ -5,8 +5,6 @@ __lazy_modules__ = ["base64", "pathlib", "timeit"]
 import argparse
 import base64
 import sys
-from base64 import b64decode as b64decode_validate
-from base64 import encodebytes as b64encodebytes
 from pathlib import Path
 from timeit import default_timer as timer
 
@@ -15,23 +13,22 @@ import pybase64
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from types import ModuleType
     from typing import Any
-
-    from pybase64._typing import Buffer, Decode, Encode, EncodeBytes
 
 
 def bench_one(
     duration: float,
     data: bytes,
-    enc: Encode,
-    dec: Decode,
-    encbytes: EncodeBytes,
-    altchars: bytes | None = None,
-    validate: bool = False,
+    module: ModuleType,
+    altchars: bytes | None,
+    kwargs: dict[str, bool | bytes],
 ) -> None:
     duration = duration / 2.0
 
+    validate = kwargs["validate"]
     if not validate and altchars is None:
+        encbytes = module.encodebytes
         number = 0
         time = timer()
         while True:
@@ -46,14 +43,15 @@ def bench_one(
             iter_ -= 1
         time = timer() - time
         print(
-            "{:<32s} {:9.3f} MB/s ({:,d} bytes -> {:,d} bytes)".format(
-                encbytes.__module__ + "." + encbytes.__name__ + ":",
+            "{:<24s} {:5.0f} MB/s ({:,d} bytes -> {:,d} bytes)".format(
+                module.__name__ + "." + encbytes.__name__ + ":",
                 ((number * len(data)) / (1024.0 * 1024.0)) / time,
                 len(data),
                 len(encodedcontent),
             ),
         )
 
+    enc = module.b64encode
     number = 0
     time = timer()
     while True:
@@ -68,36 +66,40 @@ def bench_one(
         iter_ -= 1
     time = timer() - time
     print(
-        "{:<32s} {:9.3f} MB/s ({:,d} bytes -> {:,d} bytes)".format(
-            enc.__module__ + "." + enc.__name__ + ":",
+        "{:<24s} {:5.0f} MB/s ({:,d} bytes -> {:,d} bytes)".format(
+            module.__name__ + "." + enc.__name__ + ":",
             ((number * len(data)) / (1024.0 * 1024.0)) / time,
             len(data),
             len(encodedcontent),
         ),
     )
 
-    number = 0
-    time = timer()
-    while True:
-        decodedcontent = dec(encodedcontent, altchars=altchars, validate=validate)
-        number += 1
-        if timer() - time > duration:
-            break
-    iter_ = number
-    time = timer()
-    while iter_ > 0:
-        decodedcontent = dec(encodedcontent, altchars=altchars, validate=validate)
-        iter_ -= 1
-    time = timer() - time
-    print(
-        "{:<32s} {:9.3f} MB/s ({:,d} bytes -> {:,d} bytes)".format(
-            dec.__module__ + "." + dec.__name__ + ":",
-            ((number * len(data)) / (1024.0 * 1024.0)) / time,
-            len(encodedcontent),
-            len(data),
-        ),
-    )
-    assert decodedcontent == data  # noqa: S101
+    dec = module.b64decode
+    if module is base64 and "ignorechars" in kwargs and sys.version_info < (3, 15):
+        print("{:<24s}       N/A".format(module.__name__ + "." + dec.__name__ + ":"))
+    else:
+        number = 0
+        time = timer()
+        while True:
+            decodedcontent = dec(encodedcontent, altchars=altchars, **kwargs)
+            number += 1
+            if timer() - time > duration:
+                break
+        iter_ = number
+        time = timer()
+        while iter_ > 0:
+            decodedcontent = dec(encodedcontent, altchars=altchars, **kwargs)
+            iter_ -= 1
+        time = timer() - time
+        print(
+            "{:<24s} {:5.0f} MB/s ({:,d} bytes -> {:,d} bytes)".format(
+                module.__name__ + "." + dec.__name__ + ":",
+                ((number * len(data)) / (1024.0 * 1024.0)) / time,
+                len(encodedcontent),
+                len(data),
+            ),
+        )
+        assert decodedcontent == data  # noqa: S101
 
 
 def readall(file: str) -> bytes:
@@ -115,42 +117,34 @@ def writeall(file: str, data: bytes) -> None:
 
 def benchmark(*, duration: float, input: str) -> None:  # noqa: A002
     print(__package__ + " " + pybase64.get_version())
-    # move to sys.version_info[:2] < (3, 15) after 3.15.0b1
-    if sys.hexversion < 0x030F00A8:
-
-        def _b64encode(
-            s: Buffer,
-            altchars: Buffer | None = None,
-            *,
-            padded: bool = True,  # noqa: ARG001
-            wrapcol: int = 0,  # noqa: ARG001
-        ) -> bytes:
-            return base64.b64encode(s, altchars)
-    else:  # pragma: no cover
-        _b64encode = base64.b64encode  # type: ignore[assignment]
-
     data = readall(input)
     for altchars in [None, b"-_"]:
         for validate in [False, True]:
-            print(f"bench: altchars={altchars!r:s}, validate={validate!r:s}")
-            bench_one(
-                duration,
-                data,
-                pybase64.b64encode,
-                pybase64.b64decode,
-                pybase64.encodebytes,
-                altchars,
-                validate,
-            )
-            bench_one(
-                duration,
-                data,
-                _b64encode,
-                b64decode_validate,
-                b64encodebytes,
-                altchars,
-                validate,
-            )
+            for ignorechars in [None, b"", b"@"]:
+                kwargs: dict[str, bool | bytes] = {"validate": validate}
+                if ignorechars is not None:
+                    if not validate:
+                        continue
+                    kwargs["ignorechars"] = ignorechars
+                title = f"bench: altchars={altchars!r:s}"
+                if ignorechars is None:
+                    print(f"{title}, validate={validate!r:s}")
+                else:
+                    print(f"{title}, ignorechars={ignorechars!r:s}")
+                bench_one(
+                    duration,
+                    data,
+                    pybase64,
+                    altchars,
+                    kwargs,
+                )
+                bench_one(
+                    duration,
+                    data,
+                    base64,
+                    altchars,
+                    kwargs,
+                )
 
 
 def encode(*, input: str, altchars: bytes | None, output: str) -> None:  # noqa: A002

--- a/src/pybase64/_fallback.py
+++ b/src/pybase64/_fallback.py
@@ -10,15 +10,22 @@ from pybase64._unspecified import _Unspecified
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Any, Final, Literal
+    from typing import Final, Literal
 
     from pybase64._typing import Buffer
 
-_SLOW_VALIDATION: Final = sys.version_info[:2] < (3, 12)  # fast validation with CPython 3.12+
-_PYTHON_3_15_API: Final = sys.hexversion >= 0x030F00A8  # start with 3.15.0a8, move to sys.version_info[:2] >= (3, 15)
+
+_SLOW_VALIDATION: Final = sys.version_info[:2] < (3, 13)  # fast/correct validation in CPython 3.13+
+_PYTHON_3_15_API: Final = sys.hexversion >= 0x030F00A8  # in 3.15.0a8, move sys.version_info check
 _BYTES_TYPES: Final = (bytes, bytearray)  # Types acceptable as binary data
 _EQUAL_ASCII: Final = 61  # '='
 _UNSPECIFIED: Final = _Unspecified.UNSPECIFIED
+
+if not _PYTHON_3_15_API:
+    # we consider '=' part of the alphabet, it will be handled separately
+    _BASE64_ALPHABET = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+    # we do not keep '=' on purpose, it will be handled separately
+    _IGNORECHARS_VALIDATE_FALSE: Final = bytes(i for i in range(256) if i not in _BASE64_ALPHABET)
 
 
 def _get_simd_name(flags: int) -> str:
@@ -103,16 +110,32 @@ def b64decode(  # noqa: C901
     has_bad_chars = False
     if altchars is not None:
         altchars = _validate_altchars(_get_bytes(altchars))
-    # move those 2 blocks after "if _PYTHON_3_15_API:" once python 3.15.0a8 is released
+
+    if validate is _UNSPECIFIED:
+        validate = ignorechars is not _UNSPECIFIED
+
+    if ignorechars is not _UNSPECIFIED and not validate:
+        msg = "validate must be True or unspecified when ignorechars is specified"
+        raise ValueError(msg)
+
+    if _PYTHON_3_15_API:
+        kwargs: dict[str, bool | Buffer] = {"validate": validate}
+        if ignorechars is not _UNSPECIFIED:
+            kwargs["ignorechars"] = ignorechars
+        return builtin_decode(s, altchars, **kwargs)  # type: ignore[arg-type]
+
     if ignorechars is not _UNSPECIFIED:
-        ignorechars = _get_bytes(ignorechars, allow_str=False)
+        ignorechars_ = _get_bytes(ignorechars, allow_str=False)
+
     if altchars is not None:
-        if ignorechars is _UNSPECIFIED and not _PYTHON_3_15_API:
+        if ignorechars is _UNSPECIFIED:
             for b in b"+/":
                 if b not in altchars and b in s:
                     has_bad_chars = True
                     break
-        elif ignorechars is not _UNSPECIFIED:
+            trans = bytes.maketrans(altchars, b"+/")
+            s = s.translate(trans)
+        else:
             trans_in_add = set(b"+/") - set(altchars)
             if len(trans_in_add) == 2:
                 # we don't want to use an unordered set for 2 elements
@@ -124,37 +147,44 @@ def b64decode(  # noqa: C901
                     b"+/" + bytes(set(altchars) - set(b"+/")),
                 )
             s = s.translate(trans)
-            ignorechars = ignorechars.translate(trans)
-            altchars = None
+            ignorechars_ = ignorechars_.translate(trans)
 
-    if validate is _UNSPECIFIED:
-        validate = ignorechars is not _UNSPECIFIED
-
-    if ignorechars is not _UNSPECIFIED and not validate:
-        msg = "validate must be True or unspecified when ignorechars is specified"
-        raise ValueError(msg)
-
-    if _PYTHON_3_15_API:
-        kwargs: dict[str, Any] = {"validate": validate}  # type: ignore[explicit-any]
-        if ignorechars is not _UNSPECIFIED:
-            kwargs["ignorechars"] = ignorechars
-        return builtin_decode(s, altchars, **kwargs)
-
-    if ignorechars is not _UNSPECIFIED and ignorechars:
+    if (not validate) or (ignorechars is not _UNSPECIFIED):
         # we need to filter s before calling builtin_decode this might be quite slow
-        base64_alphabet = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-        ignorechars = bytes(set(ignorechars) - set(base64_alphabet))
-        if ignorechars:
-            if 61 in ignorechars:
-                msg = "'=' not supported in ignorechars with python<3.15"
-                raise ValueError(msg)
-            s = bytes(b for b in s if b not in ignorechars)
+        if not validate:
+            has_equal = True
+            ignorechars_ = _IGNORECHARS_VALIDATE_FALSE
+        else:
+            has_equal = 61 in ignorechars_
+            ignorechars_ = bytes(set(ignorechars_) - set(_BASE64_ALPHABET))
+        if ignorechars_:
+            s = s.translate(None, delete=ignorechars_)
+        if has_equal and s:
+            if s[-1] != 61:  # there's data at the end, strip all padding bytes
+                s = s.translate(None, delete=b"=")
+            else:
+                # get s without padding
+                last_equal = len(s) - 1
+                while (last_equal >= 0) and s[last_equal] == 61:
+                    last_equal -= 1
+                last_equal += 1
+                equal_count = len(s) - last_equal
+                s2 = s[:last_equal].translate(None, delete=b"=")
+                quad_pos = len(s2) % 4
+                if quad_pos in {0, 1} or (
+                    quad_pos == 2 and equal_count == 1
+                ):  # 0 is OK, 1 will fail
+                    s = s2
+                else:
+                    s = s2 + b"=" * (4 - quad_pos)
 
-    if _SLOW_VALIDATION and validate:
-        if len(s) % 4 != 0:
-            msg = "Incorrect padding"
-            raise BinAsciiError(msg)
-        result = builtin_decode(s, altchars, validate=False)
+    # we always do validation, start with a simple check
+    if len(s) % 4 != 0:
+        msg = "Incorrect padding"
+        raise BinAsciiError(msg)
+
+    if _SLOW_VALIDATION:
+        result = builtin_decode(s, validate=False)
 
         # check length of result vs length of input
         expected_len = 0
@@ -170,7 +200,7 @@ def b64decode(  # noqa: C901
             msg = "Non-base64 digit found"
             raise BinAsciiError(msg)
     else:
-        result = builtin_decode(s, altchars, validate=validate)
+        result = builtin_decode(s, validate=True)
     if has_bad_chars:
         import warnings  # noqa: PLC0415 lazy import
 

--- a/src/pybase64/_fallback.py
+++ b/src/pybase64/_fallback.py
@@ -40,7 +40,7 @@ def _get_simd_path() -> int:
 def _get_bytes(s: str | Buffer, *, allow_str: bool = True) -> bytes | bytearray:
     if isinstance(s, str):
         if not allow_str:
-            msg = "argument should be a bytes-like object "
+            msg = "argument should be a bytes-like object"
             raise TypeError(msg) from None
         try:
             return s.encode("ascii")

--- a/src/pybase64/_fallback.py
+++ b/src/pybase64/_fallback.py
@@ -6,17 +6,19 @@ from base64 import b64encode as builtin_encode
 from base64 import encodebytes as builtin_encodebytes
 from binascii import Error as BinAsciiError
 
+from pybase64._unspecified import _Unspecified
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Final
+    from typing import Any, Final, Literal
 
     from pybase64._typing import Buffer
 
-_SLOW_VALIDATION: Final = sys.version_info[:2] < (3, 11)  # fast validation with CPython 3.11+
-_ALTCHARS_WARNINGS: Final = sys.hexversion < 0x030F00A6  # start with 3.15.0a6
-_PYTHON_3_15_API: Final = sys.hexversion >= 0x030F00A8  # start with 3.15.0a8
+_SLOW_VALIDATION: Final = sys.version_info[:2] < (3, 12)  # fast validation with CPython 3.12+
+_PYTHON_3_15_API: Final = sys.hexversion >= 0x030F00A8  # start with 3.15.0a8, move to sys.version_info[:2] >= (3, 15)
 _BYTES_TYPES: Final = (bytes, bytearray)  # Types acceptable as binary data
 _EQUAL_ASCII: Final = 61  # '='
+_UNSPECIFIED: Final = _Unspecified.UNSPECIFIED
 
 
 def _get_simd_name(flags: int) -> str:
@@ -28,8 +30,11 @@ def _get_simd_path() -> int:
     return 0
 
 
-def _get_bytes(s: str | Buffer) -> bytes | bytearray:
+def _get_bytes(s: str | Buffer, *, allow_str: bool = True) -> bytes | bytearray:
     if isinstance(s, str):
+        if not allow_str:
+            msg = "argument should be a bytes-like object "
+            raise TypeError(msg) from None
         try:
             return s.encode("ascii")
         except UnicodeEncodeError:
@@ -51,16 +56,21 @@ def _get_bytes(s: str | Buffer) -> bytes | bytearray:
         raise TypeError(msg) from None
 
 
-def _validate_altchars(altchars: bytes | bytearray) -> None:
+def _validate_altchars(altchars: bytes | bytearray) -> bytes | bytearray | None:
     if len(altchars) != 2:
         msg = "len(altchars) != 2"
         raise ValueError(msg) from None
+    if altchars == b"+/":
+        return None
+    return altchars
 
 
 def b64decode(  # noqa: C901
     s: str | Buffer,
     altchars: str | Buffer | None = None,
-    validate: bool = False,
+    validate: bool | Literal[_Unspecified.UNSPECIFIED] = _UNSPECIFIED,
+    *,
+    ignorechars: Buffer | Literal[_Unspecified.UNSPECIFIED] = _UNSPECIFIED,
 ) -> bytes:
     """Decode bytes encoded with the standard Base64 alphabet.
 
@@ -71,7 +81,15 @@ def b64decode(  # noqa: C901
     string of length 2 which specifies the alternative alphabet used instead
     of the '+' and '/' characters.
 
-    If ``validate`` is ``False`` (the default), characters that are neither in
+    If ``ignorechars`` is specified, it should be a :term:`bytes-like object`
+    containing characters to ignore from the input when ``validate`` is ``True``.
+    If ``ignorechars`` contains the pad character ``'='``,  the pad characters
+    presented before the end of the encoded data and the excess pad characters
+    will be ignored.
+    The default value of ``validate`` is ``True`` if ``ignorechars`` is specified,
+    ``False`` otherwise.
+
+    If ``validate`` is ``False``, characters that are neither in
     the normal base-64 alphabet nor the alternative alphabet are discarded
     prior to the padding check.
     If ``validate`` is ``True``, these non-alphabet characters in the input
@@ -84,13 +102,54 @@ def b64decode(  # noqa: C901
     s = _get_bytes(s)
     has_bad_chars = False
     if altchars is not None:
-        altchars = _get_bytes(altchars)
-        _validate_altchars(altchars)
-        if _ALTCHARS_WARNINGS:
+        altchars = _validate_altchars(_get_bytes(altchars))
+    # move those 2 blocks after "if _PYTHON_3_15_API:" once python 3.15.0a8 is released
+    if ignorechars is not _UNSPECIFIED:
+        ignorechars = _get_bytes(ignorechars, allow_str=False)
+    if altchars is not None:
+        if ignorechars is _UNSPECIFIED and not _PYTHON_3_15_API:
             for b in b"+/":
                 if b not in altchars and b in s:
                     has_bad_chars = True
                     break
+        elif ignorechars is not _UNSPECIFIED:
+            trans_in_add = set(b"+/") - set(altchars)
+            if len(trans_in_add) == 2:
+                # we don't want to use an unordered set for 2 elements
+                trans = bytes.maketrans(altchars + b"+/", b"+/" + altchars)
+            else:
+                # 0 or 1 element in the set
+                trans = bytes.maketrans(
+                    altchars + bytes(trans_in_add),
+                    b"+/" + bytes(set(altchars) - set(b"+/")),
+                )
+            s = s.translate(trans)
+            ignorechars = ignorechars.translate(trans)
+            altchars = None
+
+    if validate is _UNSPECIFIED:
+        validate = ignorechars is not _UNSPECIFIED
+
+    if ignorechars is not _UNSPECIFIED and not validate:
+        msg = "validate must be True or unspecified when ignorechars is specified"
+        raise ValueError(msg)
+
+    if _PYTHON_3_15_API:
+        kwargs: dict[str, Any] = {"validate": validate}  # type: ignore[explicit-any]
+        if ignorechars is not _UNSPECIFIED:
+            kwargs["ignorechars"] = ignorechars
+        return builtin_decode(s, altchars, **kwargs)
+
+    if ignorechars is not _UNSPECIFIED and ignorechars:
+        # we need to filter s before calling builtin_decode this might be quite slow
+        base64_alphabet = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        ignorechars = bytes(set(ignorechars) - set(base64_alphabet))
+        if ignorechars:
+            if 61 in ignorechars:
+                msg = "'=' not supported in ignorechars with python<3.15"
+                raise ValueError(msg)
+            s = bytes(b for b in s if b not in ignorechars)
+
     if _SLOW_VALIDATION and validate:
         if len(s) % 4 != 0:
             msg = "Incorrect padding"
@@ -112,7 +171,7 @@ def b64decode(  # noqa: C901
             raise BinAsciiError(msg)
     else:
         result = builtin_decode(s, altchars, validate=validate)
-    if _ALTCHARS_WARNINGS and has_bad_chars:
+    if has_bad_chars:
         import warnings  # noqa: PLC0415 lazy import
 
         msg = f"invalid characters '+' or '/' in Base64 data with altchars={altchars!r}"
@@ -128,7 +187,9 @@ def b64decode(  # noqa: C901
 def b64decode_as_bytearray(
     s: str | Buffer,
     altchars: str | Buffer | None = None,
-    validate: bool = False,
+    validate: bool | Literal[_Unspecified.UNSPECIFIED] = _UNSPECIFIED,
+    *,
+    ignorechars: Buffer | Literal[_Unspecified.UNSPECIFIED] = _UNSPECIFIED,
 ) -> bytearray:
     """Decode bytes encoded with the standard Base64 alphabet.
 
@@ -139,7 +200,15 @@ def b64decode_as_bytearray(
     string of length 2 which specifies the alternative alphabet used instead
     of the '+' and '/' characters.
 
-    If ``validate`` is ``False`` (the default), characters that are neither in
+    If ``ignorechars`` is specified, it should be a :term:`bytes-like object`
+    containing characters to ignore from the input when ``validate`` is ``True``.
+    If ``ignorechars`` contains the pad character ``'='``,  the pad characters
+    presented before the end of the encoded data and the excess pad characters
+    will be ignored.
+    The default value of ``validate`` is ``True`` if ``ignorechars`` is specified,
+    ``False`` otherwise.
+
+    If ``validate`` is ``False``, characters that are neither in
     the normal base-64 alphabet nor the alternative alphabet are discarded
     prior to the padding check.
     If ``validate`` is ``True``, these non-alphabet characters in the input
@@ -149,7 +218,7 @@ def b64decode_as_bytearray(
 
     A :exc:`binascii.Error` is raised if ``s`` is incorrectly padded.
     """
-    return bytearray(b64decode(s, altchars=altchars, validate=validate))
+    return bytearray(b64decode(s, altchars=altchars, validate=validate, ignorechars=ignorechars))
 
 
 def b64encode(
@@ -182,8 +251,7 @@ def b64encode(
         msg = f"{s.__class__.__name__!r:s}: underlying buffer is not C-contiguous"
         raise BufferError(msg)
     if altchars is not None:
-        altchars = _get_bytes(altchars)
-        _validate_altchars(altchars)
+        altchars = _validate_altchars(_get_bytes(altchars))
     if wrapcol < 0:
         msg = "wrapcol must be >= 0"
         raise ValueError(msg)

--- a/src/pybase64/_fallback.py
+++ b/src/pybase64/_fallback.py
@@ -21,7 +21,7 @@ _BYTES_TYPES: Final = (bytes, bytearray)  # Types acceptable as binary data
 _EQUAL_ASCII: Final = 61  # '='
 _UNSPECIFIED: Final = _Unspecified.UNSPECIFIED
 
-if not _PYTHON_3_15_API:
+if not _PYTHON_3_15_API:  # pragma: no cover
     # we consider '=' part of the alphabet, it will be handled separately
     _BASE64_ALPHABET = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
     # we do not keep '=' on purpose, it will be handled separately
@@ -118,7 +118,7 @@ def b64decode(  # noqa: C901
         msg = "validate must be True or unspecified when ignorechars is specified"
         raise ValueError(msg)
 
-    if _PYTHON_3_15_API:
+    if _PYTHON_3_15_API:  # pragma: no cover
         kwargs: dict[str, bool | Buffer] = {"validate": validate}
         if ignorechars is not _UNSPECIFIED:
             kwargs["ignorechars"] = ignorechars

--- a/src/pybase64/_pybase64.c
+++ b/src/pybase64/_pybase64.c
@@ -1479,7 +1479,7 @@ static int _pybase64_exec(PyObject *m)
     }
 
     assert(sizeof(ignoreCharsValidateFalse) == (256 - 64));
-    state->ignoreCharsValidateFalse = PyBytes_FromStringAndSize(ignoreCharsValidateFalse, sizeof(ignoreCharsValidateFalse));
+    state->ignoreCharsValidateFalse = PyBytes_FromStringAndSize((const char*)ignoreCharsValidateFalse, sizeof(ignoreCharsValidateFalse));
     if (state->ignoreCharsValidateFalse == NULL) {
         return -1;
     }

--- a/src/pybase64/_pybase64.c
+++ b/src/pybase64/_pybase64.c
@@ -25,6 +25,15 @@
 #define PYBASE64_FLAGS_APPEND_NEW_LINE  (1U << 1)
 #define PYBASE64_FLAGS_NO_PADDING       (1U << 2)
 
+#define PYBASE64_DECODE_SLOW_SUCCESS 0
+#define PYBASE64_DECODE_SLOW_EXCESS_DATA 2
+#define PYBASE64_DECODE_SLOW_LEADING_PADDING 3
+#define PYBASE64_DECODE_SLOW_DISCONTINUOUS_PADDING 4
+#define PYBASE64_DECODE_SLOW_EXCESS_PADDING 5
+#define PYBASE64_DECODE_SLOW_INCORRECT_PADDING 6
+#define PYBASE64_DECODE_SLOW_INVALID_LEN 7
+#define PYBASE64_DECODE_SLOW_INVALID_DATA 8
+
 typedef struct pybase64_state {
     PyObject *binAsciiError;
     uint32_t active_simd_flag;
@@ -39,7 +48,7 @@ typedef struct pybase64_state {
 #endif
 
 /* returns 0 on success */
-static int get_buffer(PyObject* object, Py_buffer* buffer)
+static int get_buffer(PyObject* object, Py_buffer* buffer, int bytes_like)
 {
     if (PyObject_GetBuffer(object, buffer, PyBUF_RECORDS_RO | PyBUF_C_CONTIGUOUS) != 0) {
         return -1;
@@ -52,6 +61,18 @@ static int get_buffer(PyObject* object, Py_buffer* buffer)
         return -1;
     }
 #endif
+    if (bytes_like) {
+        if (((buffer->format[0] != 'c') && (buffer->format[0] != 'b') && (buffer->format[0] != 'B')) || buffer->format[1] != '\0' ) {
+            PyBuffer_Release(buffer);
+            PyErr_Format(PyExc_TypeError, "expected single byte elements, not '%s' from %R", buffer->format, Py_TYPE(object));
+            return -1;
+        }
+        if (buffer->ndim != 1) {
+            PyBuffer_Release(buffer);
+            PyErr_Format(PyExc_TypeError, "expected 1-D data, not %d-D data from %R", buffer->ndim, Py_TYPE(object));
+            return -1;
+        }
+    }
     return 0;
 }
 
@@ -81,7 +102,7 @@ static int parse_alphabet(PyObject* alphabetObject, char* alphabet, int* useAlph
         Py_INCREF(alphabetObject);
     }
 
-    if (get_buffer(alphabetObject, &buffer) != 0) {
+    if (get_buffer(alphabetObject, &buffer, 1) != 0) {
         Py_DECREF(alphabetObject);
         return -1;
     }
@@ -139,14 +160,14 @@ static void translate_inplace(char* pSrcDst, size_t len, const char* alphabet)
         const uint8x16_t c1_ = vdupq_n_u8(c1);
 
         for (; i < (len & ~(size_t)15U); i += 16) {
-            uint8x16_t srcDst = vld1q_u8(pSrcDst + i);
+            uint8x16_t srcDst = vld1q_u8((uint8_t const*)pSrcDst + i);
             uint8x16_t m0     = vceqq_u8(srcDst, plus);
             uint8x16_t m1     = vceqq_u8(srcDst, slash);
 
             srcDst = vbslq_u8(m0, c0_, srcDst);
             srcDst = vbslq_u8(m1, c1_, srcDst);
 
-            vst1q_u8(pSrcDst + i, srcDst);
+            vst1q_u8((uint8_t*)pSrcDst + i, srcDst);
         }
     }
 #endif
@@ -164,6 +185,93 @@ static void translate_inplace(char* pSrcDst, size_t len, const char* alphabet)
 }
 
 static void translate(const char* pSrc, char* pDst, size_t len, const char* alphabet, int* has_bad_char)
+{
+    size_t i = 0U;
+    const char c0 = alphabet[0];
+    const char c1 = alphabet[1];
+    const char replace_plus = ((c0 != '/') && (c0 != '+')) ? c0 : c1;
+    const char replace_slash = ((c1 != '/') && (c1 != '+')) ? c1 : c0;
+
+    (void)has_bad_char;
+
+#ifdef __SSE2__
+    if (len >= 16U) {
+        const __m128i plus  = _mm_set1_epi8('+');
+        const __m128i slash = _mm_set1_epi8('/');
+        const __m128i c0_ = _mm_set1_epi8(c0);
+        const __m128i c1_ = _mm_set1_epi8(c1);
+        const char replace_plus__ = ((c0 == '+') || (c1 == '+')) ? '+' : replace_plus;
+        const __m128i replace_plus_ = _mm_set1_epi8(replace_plus__);
+        const char replace_slash__ = ((c0 == '/') || (c1 == '/')) ? '/' : replace_slash;
+        const __m128i replace_slash_ = _mm_set1_epi8(replace_slash__);
+
+        for (; i < (len & ~(size_t)15U); i += 16) {
+            __m128i srcDst = _mm_loadu_si128((const __m128i*)(pSrc + i));
+            __m128i m0     = _mm_cmpeq_epi8(srcDst, plus);
+            __m128i m1     = _mm_cmpeq_epi8(srcDst, slash);
+            __m128i m2     = _mm_cmpeq_epi8(srcDst, c0_);
+            __m128i m3     = _mm_cmpeq_epi8(srcDst, c1_);
+
+            srcDst = _mm_or_si128(_mm_andnot_si128(m0, srcDst), _mm_and_si128(m0, replace_plus_));
+            srcDst = _mm_or_si128(_mm_andnot_si128(m1, srcDst), _mm_and_si128(m1, replace_slash_));
+            srcDst = _mm_or_si128(_mm_andnot_si128(m2, srcDst), _mm_and_si128(m2, plus));
+            srcDst = _mm_or_si128(_mm_andnot_si128(m3, srcDst), _mm_and_si128(m3, slash));
+
+            _mm_storeu_si128((__m128i*)(pDst + i), srcDst);
+        }
+    }
+#elif BASE64_WITH_NEON64
+    if (len >= 16U) {
+        const uint8x16_t plus  = vdupq_n_u8('+');
+        const uint8x16_t slash = vdupq_n_u8('/');
+        const uint8x16_t c0_ = vdupq_n_u8(c0);
+        const uint8x16_t c1_ = vdupq_n_u8(c1);
+        const char replace_plus__ = ((c0 == '+') || (c1 == '+')) ? '+' : replace_plus;
+        const uint8x16_t replace_plus_ = vdupq_n_u8(replace_plus__);
+        const char replace_slash__ = ((c0 == '/') || (c1 == '/')) ? '/' : replace_slash;
+        const uint8x16_t replace_slash_ = vdupq_n_u8(replace_slash__);
+
+        for (; i < (len & ~(size_t)15U); i += 16) {
+            uint8x16_t srcDst = vld1q_u8((const uint8_t*)pSrc + i);
+            uint8x16_t m0     = vceqq_u8(srcDst, plus);
+            uint8x16_t m1     = vceqq_u8(srcDst, slash);
+            uint8x16_t m2     = vceqq_u8(srcDst, c0_);
+            uint8x16_t m3     = vceqq_u8(srcDst, c1_);
+
+            srcDst = vbslq_u8(m0, replace_plus_, srcDst);
+            srcDst = vbslq_u8(m1, replace_slash_, srcDst);
+            srcDst = vbslq_u8(m2, plus, srcDst);
+            srcDst = vbslq_u8(m3, slash, srcDst);
+
+            vst1q_u8((uint8_t*)pDst + i, srcDst);
+        }
+    }
+#endif
+
+    for (; i < len; ++i) {
+        const char cs = pSrc[i];
+        char cd;
+
+        if (cs == c0) {
+            cd = '+';
+        }
+        else if (cs == c1) {
+            cd = '/';
+        }
+        else if (cs == '+') {
+            cd = replace_plus;
+        }
+        else if (cs == '/') {
+            cd = replace_slash;
+        }
+        else {
+            cd = cs;
+        }
+        pDst[i] = cd;
+    }
+}
+
+static void translate_deprecated(const char* pSrc, char* pDst, size_t len, const char* alphabet, int* has_bad_char)
 {
     size_t i = 0U;
     const char c0 = alphabet[0];
@@ -211,7 +319,7 @@ static void translate(const char* pSrc, char* pDst, size_t len, const char* alph
         uint8x16_t input_has_slash_ = vdupq_n_u8(0);
 
         for (; i < (len & ~(size_t)15U); i += 16) {
-            uint8x16_t srcDst = vld1q_u8(pSrc + i);
+            uint8x16_t srcDst = vld1q_u8((uint8_t const*)pSrc + i);
             uint8x16_t m0     = vceqq_u8(srcDst, c0_);
             uint8x16_t m1     = vceqq_u8(srcDst, c1_);
 
@@ -221,7 +329,7 @@ static void translate(const char* pSrc, char* pDst, size_t len, const char* alph
             srcDst = vbslq_u8(m0, plus, srcDst);
             srcDst = vbslq_u8(m1, slash, srcDst);
 
-            vst1q_u8(pDst + i, srcDst);
+            vst1q_u8((uint8_t*)pDst + i, srcDst);
         }
 
         if (vmaxvq_u32(vreinterpretq_u32_u8(input_has_plus_))) {
@@ -245,11 +353,11 @@ static void translate(const char* pSrc, char* pDst, size_t len, const char* alph
         }
         else if (cs == '+') {
             input_has_plus = 1;
-            cd = cs; /* cd = c0;  TODO, python does not do this, add option */
+            cd = cs;
         }
         else if (cs == '/') {
             input_has_slash = 1;
-            cd = cs; /* cd = c1; TODO, python does not do this, add option */
+            cd = cs;
         }
         else {
             cd = cs;
@@ -259,24 +367,65 @@ static void translate(const char* pSrc, char* pDst, size_t len, const char* alph
     *has_bad_char |= input_has_slash | input_has_plus;
 }
 
-
-static int next_valid_padding(const uint8_t *src, size_t srclen)
+static int check_ignore(uint8_t c, Py_buffer const* ignorechars, uint32_t* ignorecache)
 {
-    int ret = 255;
+    if (ignorecache[c >> 5] & (1U << (c & 31U))) {
+        return 1;
+    }
+    if ((ignorechars->buf == NULL) || memchr(ignorechars->buf, c, ignorechars->len)) {
+        ignorecache[c >> 5] |= 1U << (c & 31U);
+        return 1;
+    }
+    return 0;
+}
 
-    while (srclen && (ret == 255))
-    {
-        ret = base64_table_dec_8bit[*src++];
+static int check_excess_data(const uint8_t** pSrc, size_t* pSrclen, Py_buffer const* ignorechars, uint32_t* ignorecache)
+{
+    uint8_t const* src = *pSrc;
+    size_t srclen = *pSrclen;
+    while (srclen && check_ignore(*src, ignorechars, ignorecache)) {
+        src++;
         srclen--;
     }
+    *pSrc = src;
+    *pSrclen = srclen;
+    return srclen > 0;
+}
 
+static int next_valid_padding(uint8_t const** pSrc, size_t* pSrclen, Py_buffer const* ignorechars, uint32_t* ignorecache)
+{
+    int ret = 255;
+    uint8_t const* src = *pSrc;
+    size_t srclen = *pSrclen;
+    if (ignorechars->buf != NULL) {
+        while (srclen && (*src != '=') && check_ignore(*src, ignorechars, ignorecache)) {
+            src++;
+            srclen--;
+        }
+        if (srclen > 0) {
+            ret = base64_table_dec_8bit[*src++];
+            srclen--;
+        }
+    }
+    else {
+        while (srclen && (ret == 255))
+        {
+            ret = base64_table_dec_8bit[*src++];
+            srclen--;
+        }
+    }
+    *pSrc = src;
+    *pSrclen = srclen;
     return ret;
 }
 
-static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, size_t*outlen)
+static int decode_slow(const uint8_t *src, size_t srclen, uint8_t* out, size_t* outlen, Py_buffer const* ignorechars)
 {
     uint8_t* out_start = out;
     uint8_t carry;
+    uint32_t ignorecache[8];
+
+    memset(ignorecache, 0, sizeof(ignorecache));
 
     while (srclen > 0U)
     {
@@ -323,7 +472,16 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
             uint8_t c = *src++; srclen--;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                continue;
+                if (check_ignore(c, ignorechars, ignorecache)) {
+                    continue;
+                }
+                if (q == 254) {
+                    if((out - out_start) == 0) {
+                        return PYBASE64_DECODE_SLOW_LEADING_PADDING;
+                    }
+                    return PYBASE64_DECODE_SLOW_EXCESS_PADDING;
+                }
+                return PYBASE64_DECODE_SLOW_INVALID_DATA;
             }
             carry = q << 2;
         }
@@ -331,12 +489,15 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return 1;
+                return PYBASE64_DECODE_SLOW_INVALID_LEN;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                continue;
+                if (check_ignore(c, ignorechars, ignorecache)) {
+                    continue;
+                }
+                return PYBASE64_DECODE_SLOW_INVALID_DATA;
             }
             *out++ = carry | (q >> 4);
             carry = q << 4;
@@ -346,18 +507,43 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return 1;
+                return PYBASE64_DECODE_SLOW_INCORRECT_PADDING;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                if (q == 254) {
-                    /* if the next valid byte is '=' => end */
-                    if (next_valid_padding(src, srclen) == 254) {
+                if (q == 254) {  /* padding */
+                    /* if the next valid byte is '=' => end or skip depending on '=' being in ignorechars */
+                    uint8_t const* src_next = src;
+                    size_t srclen_next = srclen;
+                    if (srclen == 0) {
+                        return PYBASE64_DECODE_SLOW_INCORRECT_PADDING;
+                    }
+                    if (next_valid_padding(&src_next, &srclen_next, ignorechars, ignorecache) == 254) {
+                        if (ignorechars->buf != NULL) {
+                            if (check_excess_data(&src_next, &srclen_next, ignorechars, ignorecache)) {
+                                if (check_ignore('=', ignorechars, ignorecache)) {
+                                    /* restart at excess data */
+                                    src = src_next;
+                                    srclen = srclen_next;
+                                    continue;
+                                }
+                                if (*src_next == '=') {
+                                    return PYBASE64_DECODE_SLOW_EXCESS_PADDING;
+                                }
+                                return PYBASE64_DECODE_SLOW_EXCESS_DATA;
+                            }
+                        }
                         goto END;
                     }
+                    else if (!check_ignore('=', ignorechars, ignorecache)) {
+                        return PYBASE64_DECODE_SLOW_DISCONTINUOUS_PADDING;
+                    }
                 }
-                continue;
+                if (check_ignore(c, ignorechars, ignorecache)) {
+                    continue;
+                }
+                return PYBASE64_DECODE_SLOW_INVALID_DATA;
             }
             *out++ = carry | (q >> 2);
             carry = q << 6;
@@ -367,16 +553,30 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
         for(;;)
         {
             if (srclen-- == 0) {
-                return 1;
+                return PYBASE64_DECODE_SLOW_INCORRECT_PADDING;
             }
             uint8_t c = *src++;
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
-                if (q == 254) {
+                if (q == 254) {  /* padding */
+                    if (ignorechars->buf != NULL) {
+                        if (check_excess_data(&src, &srclen, ignorechars, ignorecache)) {
+                            if (check_ignore('=', ignorechars, ignorecache)) {
+                                continue;
+                            }
+                            if (*src == '=') {
+                                return PYBASE64_DECODE_SLOW_EXCESS_PADDING;
+                            }
+                            return PYBASE64_DECODE_SLOW_EXCESS_DATA;
+                        }
+                    }
                     srclen = 0U;
                     break;
                 }
-                continue;
+                if (check_ignore(c, ignorechars, ignorecache)) {
+                    continue;
+                }
+                return PYBASE64_DECODE_SLOW_INVALID_DATA;
             }
             *out++ = carry | q;
             break;
@@ -384,7 +584,7 @@ static int decode_novalidate(const uint8_t *src, size_t srclen, uint8_t *out, si
     }
 END:
     *outlen = out - out_start;
-    return 0;
+    return PYBASE64_DECODE_SLOW_SUCCESS;
 }
 
 static PyObject* pybase64_encode_impl_core(PyObject* self, Py_buffer const* buffer, char const* alphabet, Py_ssize_t wrapcol, unsigned int flags)
@@ -474,8 +674,7 @@ static PyObject* pybase64_encode_impl_core(PyObject* self, Py_buffer const* buff
     }
 
     if (wrapcol) {
-        const size_t dst_len = (size_t)wrapcol;
-        const size_t dst_slice = dst_len + 1U;
+        const size_t dst_slice = (size_t)wrapcol + 1U;
         const Py_ssize_t src_slice = (Py_ssize_t)((dst_slice / 4U) * 3U);
         Py_ssize_t len = buffer->len;
         const char* src = (const char*)buffer->buf;
@@ -483,6 +682,8 @@ static PyObject* pybase64_encode_impl_core(PyObject* self, Py_buffer const* buff
 
         if (alphabet) {
             while (out_len > dst_slice) {
+                size_t dst_len = (size_t)wrapcol;
+
                 base64_encode(src, src_slice, dst, &dst_len, libbase64_simd_flag);
                 translate_inplace(dst, dst_len, alphabet);
                 dst[dst_len] = '\n';
@@ -499,6 +700,7 @@ static PyObject* pybase64_encode_impl_core(PyObject* self, Py_buffer const* buff
         }
         else {
             while (out_len > dst_slice) {
+                size_t dst_len = (size_t)wrapcol;
                 base64_encode(src, src_slice, dst, &dst_len, libbase64_simd_flag);
                 dst[dst_len] = '\n';
 
@@ -611,7 +813,7 @@ static PyObject* pybase64_encode_impl(PyObject* self, PyObject* args, PyObject *
         return NULL;
     }
 
-    if (get_buffer(in_object, &buffer) != 0) {
+    if (get_buffer(in_object, &buffer, 0) != 0) {
         return NULL;
     }
 
@@ -636,18 +838,72 @@ static PyObject* pybase64_encode_as_string(PyObject* self, PyObject* args, PyObj
     return pybase64_encode_impl(self, args, kwds, PYBASE64_FLAGS_ENCODE_AS_STRING);
 }
 
+static PyObject* get_ignorechars_buffer(PyObject* object, Py_buffer* buffer, char const* alphabet)
+{
+    if (get_buffer(object, buffer, 1) != 0) {
+        return NULL;
+    }
+    if ((buffer->len == 0) || (alphabet == NULL)) {
+        Py_INCREF(object);
+        return object;
+    }
+
+    PyObject* result = NULL;
+    PyObject* tmp_result = NULL;
+    void* translate_dst;
+    Py_buffer in_buffer = *buffer;
+#if PY_VERSION_HEX >= 0x030f0000
+    PyBytesWriter* writer = PyBytesWriter_Create(in_buffer.len);
+    if (writer == NULL) {
+        goto END;
+    }
+    translate_dst = PyBytesWriter_GetData(writer);
+#else
+    tmp_result = PyBytes_FromStringAndSize(NULL, in_buffer.len);
+    if (tmp_result == NULL) {
+        goto END;
+    }
+    translate_dst = PyBytes_AS_STRING(tmp_result);
+#endif
+
+    translate(in_buffer.buf, translate_dst, in_buffer.len, alphabet, NULL);
+
+#if PY_VERSION_HEX >= 0x030f0000
+    tmp_result = PyBytesWriter_Finish(writer);
+    writer = NULL;
+    if (tmp_result == NULL) {
+        goto END;
+    }
+#endif
+    if (get_buffer(tmp_result, buffer, 0) != 0) {
+       goto END;
+    }
+    result = tmp_result;
+    tmp_result = NULL;
+END:
+    Py_XDECREF(tmp_result);
+#if PY_VERSION_HEX >= 0x030f0000
+    PyBytesWriter_Discard(writer);
+#endif
+    PyBuffer_Release(&in_buffer);
+    return result;
+}
+
 static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *kwds, int return_bytearray)
 {
-    static const char *kwlist[] = { "", "altchars", "validate", NULL };
+    static const char *kwlist[] = { "", "altchars", "validate", "ignorechars", NULL };
 
     int use_alphabet = 0;
     int has_bad_char = 0;
     char alphabet[2];
-    char validation = 0;
+    int validation;
     Py_buffer buffer;
+    Py_buffer ignorechars_buffer;
     size_t out_len;
     PyObject* in_alphabet = NULL;
     PyObject* in_object;
+    PyObject* validation_object = NULL;
+    PyObject* ignorechars_object = NULL;
     PyObject* out_object = NULL;
 #if PY_VERSION_HEX >= 0x030f0000
     PyBytesWriter* writer = NULL;
@@ -656,17 +912,50 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
     Py_ssize_t source_len;
     int source_use_buffer = 0;
     void* dest;
+    void (*translate_fn)(const char*, char*, size_t, const char*, int*) = &translate_deprecated;
     pybase64_state *state = (pybase64_state*)PyModule_GetState(self);
     if (state == NULL) {
         return NULL;
     }
     /* Parse the input tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Ob", KW_CONST_CAST kwlist, &in_object, &in_alphabet, &validation)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO$O", KW_CONST_CAST kwlist, &in_object, &in_alphabet, &validation_object, &ignorechars_object)) {
         return NULL;
+    }
+
+    if (validation_object == NULL) {
+        validation = (ignorechars_object != NULL);
+    }
+    else {
+        validation = PyObject_IsTrue(validation_object);
+        if (validation < 0) {
+            return NULL;
+        }
+        if ((ignorechars_object != NULL) && !validation ) {
+            PyErr_SetString(PyExc_ValueError, "validate must be True or unspecified when ignorechars is specified");
+            return NULL;
+        }
     }
 
     if (parse_alphabet(in_alphabet, alphabet, &use_alphabet) != 0) {
         return NULL;
+    }
+
+    memset(&ignorechars_buffer, 0, sizeof(ignorechars_buffer));
+    if (ignorechars_object != NULL) {
+        ignorechars_object = get_ignorechars_buffer(ignorechars_object, &ignorechars_buffer, use_alphabet ? alphabet : NULL);
+        if (ignorechars_object == NULL) {
+            return NULL;
+        }
+        if (ignorechars_buffer.len == 0) {
+            PyBuffer_Release(&ignorechars_buffer);
+            Py_DECREF(ignorechars_object);
+            ignorechars_object = NULL;
+            validation = 1;
+        }
+        else {
+            validation = 0;
+        }
+        translate_fn = &translate;
     }
 
     if (PyUnicode_Check(in_object)) {
@@ -680,6 +969,10 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
                 if (PyErr_ExceptionMatches(PyExc_UnicodeEncodeError)) {
                     PyErr_SetString(PyExc_ValueError, "string argument should contain only ASCII characters");
                 }
+                if (ignorechars_object) {
+                    PyBuffer_Release(&ignorechars_buffer);
+                    Py_DECREF(ignorechars_object);
+                }
                 return NULL;
             }
         }
@@ -688,8 +981,12 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         Py_INCREF(in_object);
     }
     if (source == NULL) {
-        if (get_buffer(in_object, &buffer) != 0) {
+        if (get_buffer(in_object, &buffer, 0) != 0) {
             Py_DECREF(in_object);
+            if (ignorechars_object) {
+                PyBuffer_Release(&ignorechars_buffer);
+                Py_DECREF(ignorechars_object);
+            }
             return NULL;
         }
         source = buffer.buf;
@@ -719,7 +1016,7 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         /* not interacting with Python objects from here, release the GIL */
         Py_BEGIN_ALLOW_THREADS
 
-        translate(source, translate_dst, source_len, alphabet, &has_bad_char);
+        translate_fn(source, translate_dst, source_len, alphabet, &has_bad_char);
 
         /* restore the GIL */
         Py_END_ALLOW_THREADS
@@ -737,7 +1034,7 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
             Py_DECREF(in_object);
         }
         in_object = translate_object;
-        if (get_buffer(in_object, &buffer) != 0) {
+        if (get_buffer(in_object, &buffer, 0) != 0) {
             Py_DECREF(in_object);
             return NULL;
         }
@@ -779,13 +1076,36 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         /* not interacting with Python objects from here, release the GIL */
         Py_BEGIN_ALLOW_THREADS
 
-        result = decode_novalidate(source, source_len, dest, &out_len);
+        result = decode_slow(source, source_len, dest, &out_len, &ignorechars_buffer);
 
         /* restore the GIL */
         Py_END_ALLOW_THREADS
 
-        if (result != 0) {
-            PyErr_SetString(state->binAsciiError, "Incorrect padding");
+        if (result != PYBASE64_DECODE_SLOW_SUCCESS) {
+            switch(result)
+            {
+            case PYBASE64_DECODE_SLOW_INCORRECT_PADDING:
+                PyErr_SetString(state->binAsciiError, "Incorrect padding");
+                break;
+            case PYBASE64_DECODE_SLOW_EXCESS_DATA:
+                PyErr_SetString(state->binAsciiError, "Excess data after padding");
+                break;
+            case PYBASE64_DECODE_SLOW_LEADING_PADDING:
+                PyErr_SetString(state->binAsciiError, "Leading padding");
+                break;
+            case PYBASE64_DECODE_SLOW_DISCONTINUOUS_PADDING:
+                PyErr_SetString(state->binAsciiError, "Discontinuous padding");
+                break;
+            case PYBASE64_DECODE_SLOW_EXCESS_PADDING:
+                PyErr_SetString(state->binAsciiError, "Excess padding");
+                break;
+            case PYBASE64_DECODE_SLOW_INVALID_LEN:
+                PyErr_SetString(state->binAsciiError, "Invalid number of data characters");
+                break;
+            case PYBASE64_DECODE_SLOW_INVALID_DATA:
+                PyErr_SetString(state->binAsciiError, "Non-base64 digit found");
+                break;
+            }
             goto EXCEPT;
         }
     }
@@ -806,7 +1126,7 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         while (len > src_slice) {
             size_t dst_len = dst_slice;
 
-            translate(src, cache, src_slice, alphabet, &has_bad_char);
+            translate_fn(src, cache, src_slice, alphabet, &has_bad_char);
             result = base64_decode(cache, src_slice, dst, &dst_len, libbase64_simd_flag);
             if (result <= 0) {
                 break;
@@ -818,7 +1138,7 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
             dst += dst_slice;
         }
         if (result > 0) {
-            translate(src, cache, len, alphabet, &has_bad_char);
+            translate_fn(src, cache, len, alphabet, &has_bad_char);
             result = base64_decode(cache, len, dst, &out_len, libbase64_simd_flag);
         }
 
@@ -870,6 +1190,10 @@ FINALLY:
         PyBuffer_Release(&buffer);
         Py_DECREF(in_object);
     }
+    if (ignorechars_object) {
+        PyBuffer_Release(&ignorechars_buffer);
+        Py_DECREF(ignorechars_object);
+    }
     if (has_bad_char && (out_object != NULL)) {
         static const char format_validation[] = "invalid characters '+' or '/' in Base64 data with altchars=%R and validate=True will be an error in future versions";
         static const char format_no_validation[] = "invalid characters '+' or '/' in Base64 data with altchars=%R and validate=False will be discarded in future versions";
@@ -898,17 +1222,10 @@ static PyObject* pybase64_encodebytes(PyObject* self, PyObject* in_object)
     Py_buffer buffer;
     PyObject* out_object;
 
-    if (get_buffer(in_object, &buffer) != 0) {
+    if (get_buffer(in_object, &buffer, 1) != 0) {
         return NULL;
     }
-    if (((buffer.format[0] != 'c') && (buffer.format[0] != 'b') && (buffer.format[0] != 'B')) || buffer.format[1] != '\0' ) {
-        PyBuffer_Release(&buffer);
-        return PyErr_Format(PyExc_TypeError, "expected single byte elements, not '%s' from %R", buffer.format, Py_TYPE(in_object));
-    }
-    if (buffer.ndim != 1) {
-        PyBuffer_Release(&buffer);
-        return PyErr_Format(PyExc_TypeError, "expected 1-D data, not %d-D data from %R", buffer.ndim, Py_TYPE(in_object));
-    }
+
     out_object = pybase64_encode_impl_core(self, &buffer, NULL, 76, PYBASE64_FLAGS_APPEND_NEW_LINE);
 
     PyBuffer_Release(&buffer);

--- a/src/pybase64/_pybase64.c
+++ b/src/pybase64/_pybase64.c
@@ -36,6 +36,7 @@
 
 typedef struct pybase64_state {
     PyObject *binAsciiError;
+    PyObject *ignoreCharsValidateFalse;
     uint32_t active_simd_flag;
     uint32_t simd_flags;
     int libbase64_simd_flag;
@@ -372,7 +373,7 @@ static int check_ignore(uint8_t c, Py_buffer const* ignorechars, uint32_t* ignor
     if (ignorecache[c >> 5] & (1U << (c & 31U))) {
         return 1;
     }
-    if ((ignorechars->buf == NULL) || memchr(ignorechars->buf, c, ignorechars->len)) {
+    if (memchr(ignorechars->buf, c, ignorechars->len)) {
         ignorecache[c >> 5] |= 1U << (c & 31U);
         return 1;
     }
@@ -397,22 +398,13 @@ static int next_valid_padding(uint8_t const** pSrc, size_t* pSrclen, Py_buffer c
     int ret = 255;
     uint8_t const* src = *pSrc;
     size_t srclen = *pSrclen;
-    if (ignorechars->buf != NULL) {
-        while (srclen && (*src != '=') && check_ignore(*src, ignorechars, ignorecache)) {
-            src++;
-            srclen--;
-        }
-        if (srclen > 0) {
-            ret = base64_table_dec_8bit[*src++];
-            srclen--;
-        }
+    while (srclen && (*src != '=') && check_ignore(*src, ignorechars, ignorecache)) {
+        src++;
+        srclen--;
     }
-    else {
-        while (srclen && (ret == 255))
-        {
-            ret = base64_table_dec_8bit[*src++];
-            srclen--;
-        }
+    if (srclen > 0) {
+        ret = base64_table_dec_8bit[*src++];
+        srclen--;
     }
     *pSrc = src;
     *pSrclen = srclen;
@@ -520,19 +512,17 @@ static int decode_slow(const uint8_t *src, size_t srclen, uint8_t* out, size_t* 
                         return PYBASE64_DECODE_SLOW_INCORRECT_PADDING;
                     }
                     if (next_valid_padding(&src_next, &srclen_next, ignorechars, ignorecache) == 254) {
-                        if (ignorechars->buf != NULL) {
-                            if (check_excess_data(&src_next, &srclen_next, ignorechars, ignorecache)) {
-                                if (check_ignore('=', ignorechars, ignorecache)) {
-                                    /* restart at excess data */
-                                    src = src_next;
-                                    srclen = srclen_next;
-                                    continue;
-                                }
-                                if (*src_next == '=') {
-                                    return PYBASE64_DECODE_SLOW_EXCESS_PADDING;
-                                }
-                                return PYBASE64_DECODE_SLOW_EXCESS_DATA;
+                        if (check_excess_data(&src_next, &srclen_next, ignorechars, ignorecache)) {
+                            if (check_ignore('=', ignorechars, ignorecache)) {
+                                /* restart at excess data */
+                                src = src_next;
+                                srclen = srclen_next;
+                                continue;
                             }
+                            if (*src_next == '=') {
+                                return PYBASE64_DECODE_SLOW_EXCESS_PADDING;
+                            }
+                            return PYBASE64_DECODE_SLOW_EXCESS_DATA;
                         }
                         goto END;
                     }
@@ -559,16 +549,14 @@ static int decode_slow(const uint8_t *src, size_t srclen, uint8_t* out, size_t* 
             uint8_t q;
             if ((q = base64_table_dec_8bit[c]) >= 254) {
                 if (q == 254) {  /* padding */
-                    if (ignorechars->buf != NULL) {
-                        if (check_excess_data(&src, &srclen, ignorechars, ignorecache)) {
-                            if (check_ignore('=', ignorechars, ignorecache)) {
-                                continue;
-                            }
-                            if (*src == '=') {
-                                return PYBASE64_DECODE_SLOW_EXCESS_PADDING;
-                            }
-                            return PYBASE64_DECODE_SLOW_EXCESS_DATA;
+                    if (check_excess_data(&src, &srclen, ignorechars, ignorecache)) {
+                        if (check_ignore('=', ignorechars, ignorecache)) {
+                            continue;
                         }
+                        if (*src == '=') {
+                            return PYBASE64_DECODE_SLOW_EXCESS_PADDING;
+                        }
+                        return PYBASE64_DECODE_SLOW_EXCESS_DATA;
                     }
                     srclen = 0U;
                     break;
@@ -894,6 +882,7 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
     static const char *kwlist[] = { "", "altchars", "validate", "ignorechars", NULL };
 
     int use_alphabet = 0;
+    int use_alphabet_for_ignore_chars;
     int has_bad_char = 0;
     char alphabet[2];
     int validation;
@@ -940,11 +929,20 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         return NULL;
     }
 
-    memset(&ignorechars_buffer, 0, sizeof(ignorechars_buffer));
+    use_alphabet_for_ignore_chars = use_alphabet;
+    if (!validation) {
+        assert(ignorechars_object == NULL);
+        ignorechars_object = state->ignoreCharsValidateFalse;
+        use_alphabet_for_ignore_chars = 0;
+    }
+
     if (ignorechars_object != NULL) {
-        ignorechars_object = get_ignorechars_buffer(ignorechars_object, &ignorechars_buffer, use_alphabet ? alphabet : NULL);
+        ignorechars_object = get_ignorechars_buffer(ignorechars_object, &ignorechars_buffer, use_alphabet_for_ignore_chars ? alphabet : NULL);
         if (ignorechars_object == NULL) {
             return NULL;
+        }
+        if (validation) {
+            translate_fn = &translate;
         }
         if (ignorechars_buffer.len == 0) {
             PyBuffer_Release(&ignorechars_buffer);
@@ -955,7 +953,6 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         else {
             validation = 0;
         }
-        translate_fn = &translate;
     }
 
     if (PyUnicode_Check(in_object)) {
@@ -1447,6 +1444,24 @@ static PyObject* pybase64_import_BinAsciiError()
 
 static int _pybase64_exec(PyObject *m)
 {
+    static uint8_t const ignoreCharsValidateFalse[] = {
+          0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,
+         16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,
+         32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,       44,  45,  46,      /* 43: '+', 47: '/' */
+         /* 48: '0' -> 57: '9' */                          58,  59,  60,  61,  62,  63,
+         64, /* 65: 'A' -> 90: 'Z' */
+                                                                91,  92,  93,  94,  95,
+         96, /* 97: 'a' -> 122: 'z' */
+                                                               123, 124, 125, 126, 127,
+        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
+        144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
+        160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+        176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
+        192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207,
+        208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223,
+        224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+        240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255,
+    };
     pybase64_state *state = (pybase64_state*)PyModule_GetState(m);
     if (state == NULL) {
         return -1;
@@ -1463,6 +1478,12 @@ static int _pybase64_exec(PyObject *m)
         return -1;
     }
 
+    assert(sizeof(ignoreCharsValidateFalse) == (256 - 64));
+    state->ignoreCharsValidateFalse = PyBytes_FromStringAndSize(ignoreCharsValidateFalse, sizeof(ignoreCharsValidateFalse));
+    if (state->ignoreCharsValidateFalse == NULL) {
+        return -1;
+    }
+
     state->simd_flags = pybase64_get_simd_flags();
     set_simd_path(state, state->simd_flags);
 
@@ -1474,6 +1495,7 @@ static int _pybase64_traverse(PyObject *m, visitproc visit, void *arg)
     pybase64_state *state = (pybase64_state*)PyModule_GetState(m);
     if (state) {
         Py_VISIT(state->binAsciiError);
+        Py_VISIT(state->ignoreCharsValidateFalse);
     }
     return 0;
 }
@@ -1483,6 +1505,7 @@ static int _pybase64_clear(PyObject *m)
     pybase64_state *state = (pybase64_state*)PyModule_GetState(m);
     if (state) {
         Py_CLEAR(state->binAsciiError);
+        Py_CLEAR(state->ignoreCharsValidateFalse);
     }
     return 0;
 }

--- a/src/pybase64/_pybase64.pyi
+++ b/src/pybase64/_pybase64.pyi
@@ -1,4 +1,7 @@
+from typing import Literal
+
 from pybase64._typing import Buffer
+from pybase64._unspecified import _Unspecified
 
 def _get_simd_flags_compile() -> int: ...
 def _get_simd_flags_runtime() -> int: ...
@@ -8,12 +11,16 @@ def _set_simd_path(flags: int) -> None: ...
 def b64decode(
     s: str | Buffer,
     altchars: str | Buffer | None = None,
-    validate: bool = False,
+    validate: bool | Literal[_Unspecified.UNSPECIFIED] = ...,
+    *,
+    ignorechars: Buffer | Literal[_Unspecified.UNSPECIFIED] = ...,
 ) -> bytes: ...
 def b64decode_as_bytearray(
     s: str | Buffer,
     altchars: str | Buffer | None = None,
-    validate: bool = False,
+    validate: bool | Literal[_Unspecified.UNSPECIFIED] = ...,
+    *,
+    ignorechars: Buffer | Literal[_Unspecified.UNSPECIFIED] = ...,
 ) -> bytearray: ...
 def b64encode(
     s: Buffer,

--- a/src/pybase64/_typing.py
+++ b/src/pybase64/_typing.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import sys
-from typing import Protocol
+from typing import Literal, Protocol
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer
 else:
     from collections.abc import Buffer
+
+from pybase64._unspecified import _Unspecified
 
 
 class Decode(Protocol):
@@ -17,7 +19,9 @@ class Decode(Protocol):
         self,
         s: str | Buffer,
         altchars: str | Buffer | None = None,
-        validate: bool = False,
+        validate: bool | Literal[_Unspecified.UNSPECIFIED] = _Unspecified.UNSPECIFIED,
+        *,
+        ignorechars: Buffer | Literal[_Unspecified.UNSPECIFIED] = _Unspecified.UNSPECIFIED,
     ) -> bytes: ...
 
 
@@ -35,11 +39,4 @@ class Encode(Protocol):
     ) -> bytes: ...
 
 
-class EncodeBytes(Protocol):
-    __name__: str
-    __module__: str
-
-    def __call__(self, s: Buffer) -> bytes: ...
-
-
-__all__ = ("Buffer", "Decode", "Encode", "EncodeBytes")
+__all__ = ("Buffer", "Decode", "Encode")

--- a/src/pybase64/_unspecified.py
+++ b/src/pybase64/_unspecified.py
@@ -2,4 +2,7 @@ from enum import Enum
 
 
 class _Unspecified(Enum):
+    """For internal use only, external usage is undefined behavior."""
+
     UNSPECIFIED = 0
+    """For internal use only, external usage is undefined behavior."""

--- a/src/pybase64/_unspecified.py
+++ b/src/pybase64/_unspecified.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class _Unspecified(Enum):
+    UNSPECIFIED = 0

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import base64
+import re
 import sys
 import warnings
 from base64 import encodebytes as b64encodebytes
 from binascii import Error as BinAsciiError
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 
 import pybase64
+from pybase64._unspecified import _Unspecified
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -18,6 +20,8 @@ if TYPE_CHECKING:
     from pybase64._typing import Buffer, Decode, Encode
 
 from . import utils
+
+IGNORECHARS_EQUAL_SUPPORTED = utils.has_extension or sys.version_info >= (3, 15)
 
 
 def b64encode_as_string(
@@ -34,10 +38,17 @@ def b64encode_as_string(
 def b64decode_as_bytearray(
     s: str | Buffer,
     altchars: str | Buffer | None = None,
-    validate: bool = False,
+    validate: bool | Literal[_Unspecified.UNSPECIFIED] = _Unspecified.UNSPECIFIED,
+    *,
+    ignorechars: Buffer | Literal[_Unspecified.UNSPECIFIED] = _Unspecified.UNSPECIFIED,
 ) -> bytes:
     """Helper returning bytes instead of bytearray for tests"""
-    return bytes(pybase64.b64decode_as_bytearray(s, altchars, validate))
+    kwargs: dict[str, Any] = {}
+    if not isinstance(validate, _Unspecified):
+        kwargs["validate"] = validate
+    if not isinstance(ignorechars, _Unspecified):
+        kwargs["ignorechars"] = ignorechars
+    return bytes(pybase64.b64decode_as_bytearray(s, altchars, **kwargs))
 
 
 param_encode_functions = pytest.mark.parametrize("efn", [pybase64.b64encode, b64encode_as_string])
@@ -380,6 +391,9 @@ params_invalid_data_novalidate_values = [
     ["a\x80aa", None, ValueError, "ASCII|Non-base64 digit found"],
     [b"a\x80aa", None, BinAsciiError, "Incorrect padding|Non-base64 digit found|Only base64 data"],
     ["a\x80aaa", None, ValueError, "ASCII|Non-base64 digit found"],
+    [b"ab", None, BinAsciiError, "Incorrect padding|Non-base64 digit found"],
+    [b"abc", None, BinAsciiError, "Incorrect padding|Non-base64 digit found"],
+    [b"ab=", None, BinAsciiError, "Incorrect padding|Non-base64 digit found"],
 ]
 params_invalid_data_validate_values = [
     [b"\x00\x00\x00\x00", None, BinAsciiError, None],
@@ -466,6 +480,22 @@ def test_invalid_data_dec_validate(
     utils.unused_args(simd)  # simd is a parameter in order to control the order of tests
     with pytest.raises(exception, match=match):
         dfn(vector, altchars, validate=True)
+
+
+@utils.param_simd
+@params_invalid_data_all
+@param_decode_functions
+def test_invalid_data_dec_ignorechars_empty(
+    dfn: Decode,
+    vector: Any,
+    altchars: Buffer | None,
+    exception: type[BaseException],
+    match: str | None,
+    simd: int,
+) -> None:
+    utils.unused_args(simd)  # simd is a parameter in order to control the order of tests
+    with pytest.raises(exception, match=match):
+        dfn(vector, altchars, ignorechars=b"")
 
 
 @utils.param_simd
@@ -665,3 +695,155 @@ def test_b64encode_padded(efn: Encode, vector: bytes, expected: bytes, simd: int
 def test_urlsafe_b64encode_padded(vector: bytes, expected: bytes, simd: int) -> None:
     utils.unused_args(simd)
     assert pybase64.urlsafe_b64encode(vector, padded=False) == expected
+
+
+@utils.param_simd
+def test_ignorechars_altchars_limit(simd: int) -> None:
+    utils.unused_args(simd)
+    assert pybase64.b64decode(b"/----", altchars=b"-+", ignorechars=b"/") == b"\xfb\xef\xbe"
+    assert pybase64.b64decode(b"/----", altchars=b"+-", ignorechars=b"/") == b"\xff\xff\xff"
+    assert pybase64.b64decode(b"+----", altchars=b"-/", ignorechars=b"+") == b"\xfb\xef\xbe"
+    assert pybase64.b64decode(b"+----", altchars=b"/-", ignorechars=b"+") == b"\xff\xff\xff"
+    assert pybase64.b64decode(b"+/+/", altchars=b"/+", ignorechars=b"") == b"\xff\xef\xfe"
+    assert pybase64.b64decode(b"/+/+", altchars=b"+/", ignorechars=b"") == b"\xff\xef\xfe"
+
+
+@utils.param_simd
+def test_ignorechars_invalid(simd: int) -> None:
+    utils.unused_args(simd)
+    with pytest.raises(TypeError):
+        pybase64.b64decode(b"", ignorechars="")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        pybase64.b64decode(b"", ignorechars=[])  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        pybase64.b64decode(b"", ignorechars=None)  # type: ignore[arg-type]
+    msg = re.escape("validate must be True or unspecified when ignorechars is specified")
+    with pytest.raises(ValueError, match=msg):
+        pybase64.b64decode(b"", validate=False, ignorechars=b"")
+    with pytest.raises(ValueError, match="ASCII"):
+        pybase64.b64decode("YW\x80Jj", ignorechars=b"\x80")
+
+
+@param_decode_functions
+@utils.param_simd
+def test_ignorechars(dfn: Decode, simd: int) -> None:
+    utils.unused_args(simd)  # simd is a parameter in order to control the order of tests
+    assert dfn(b"YW\nJj", ignorechars=b"\n") == b"abc"
+    assert dfn(b"YW\nJj", ignorechars=bytearray(b"\n")) == b"abc"
+    assert dfn(b"YW\nJj", ignorechars=memoryview(b"\n")) == b"abc"
+    assert dfn(b"{YWJj", ignorechars=b"{}") == b"abc"
+    assert dfn(b"Y}WJj", ignorechars=b"{}") == b"abc"
+    assert dfn(b"YW{Jj", ignorechars=b"{}") == b"abc"
+    assert dfn(b"YWJ}j", ignorechars=b"{}") == b"abc"
+    # base64 alphabet ignored in ignorechars
+    assert dfn(b"YWJj", ignorechars=b"Y") == b"abc"
+    assert dfn(b"YW{Jj", ignorechars=b"Y{") == b"abc"
+    # non ASCII
+    assert dfn(b"YW\x80Jj", ignorechars=b"\x80") == b"abc"
+
+
+@pytest.mark.parametrize(
+    ("data", "ignorechars", "no_validation_expected_result", "ignorechars_expected_result"),
+    [
+        # excess padding
+        (b"ab===", b"=", b"i", None),
+        (b"ab====", b"=", b"i", None),
+        (b"abc==", b"=", b"i\xb7", None),
+        (b"abc===", b"=", b"i\xb7", None),
+        (b"abc====", b"=", b"i\xb7", None),
+        (b"abc=====", b"=", b"i\xb7", None),
+        (b"abcd=", b"=", b"i\xb7\x1d", None),
+        (b"abcd==", b"=", b"i\xb7\x1d", None),
+        (b"abcd===", b"=", b"i\xb7\x1d", None),
+        (b"abcd====", b"=", b"i\xb7\x1d", None),
+        (b"abcd=====", b"=", b"i\xb7\x1d", None),
+        (b"abcd=efgh", b"=", b"i\xb7\x1dy\xf8!", None),
+        (b"abcd==efgh", b"=", b"i\xb7\x1dy\xf8!", None),
+        (b"abcd===efgh", b"=", b"i\xb7\x1dy\xf8!", None),
+        (b"abcd====efgh", b"=", b"i\xb7\x1dy\xf8!", None),
+        (b"abcd=====efgh", b"=", b"i\xb7\x1dy\xf8!", None),
+        (b"YWJj=", b"=", b"abc", None),
+        # leading padding
+        (b"=", b"=", b"", None),
+        (b"==", b"=", b"", None),
+        (b"===", b"=", b"", None),
+        (b"====", b"=", b"", None),
+        (b"=====", b"=", b"", None),
+        (b"=abcd", b"=", b"i\xb7\x1d", None),
+        (b"==abcd", b"=", b"i\xb7\x1d", None),
+        (b"===abcd", b"=", b"i\xb7\x1d", None),
+        (b"====abcd", b"=", b"i\xb7\x1d", None),
+        (b"=====abcd", b"=", b"i\xb7\x1d", None),
+        (b"[==", b"[=", b"", None),
+        (b"=YWJj", b"=", b"abc", None),
+        # invalid length
+        (b"a=b==", b"=", b"i", None),
+        (b"a=bc=", b"=", b"i\xb7", None),
+        (b"a=bc==", b"=", b"i\xb7", None),
+        (b"a=bcd", b"=", b"i\xb7\x1d", None),
+        (b"a=bcd=", b"=", b"i\xb7\x1d", None),
+        # discontinuous padding
+        (b"ab=c=", b"=", b"i\xb7", None),
+        (b"ab=cd", b"=", b"i\xb7\x1d", None),
+        (b"ab=cd==", b"=", b"i\xb7\x1d", None),
+        (b"Y=WJj", b"=", b"abc", None),
+        (b"Y==WJj", b"=", b"abc", None),
+        (b"YW=Jj", b"=", b"abc", None),
+        # excess data
+        (b"ab==c", b"=", b"i", BinAsciiError),
+        (b"ab==cd", b"=", b"i", b"i\xb7\x1d"),
+        (b"abc=d", b"=", b"i\xb7", b"i\xb7\x1d"),
+        # invalid data
+        (b"ab:(){:|:&};:==", b":;(){}|&", b"i", None),
+        (b"\nab==", b"\n", b"i", None),
+        (b"ab==\n", b"\n", b"i", None),
+        (b"a\nb==", b"\n", b"i", None),
+        (b"a\x00b==", b"\x00", b"i", None),
+        (b"a\x00b==", b"@\x00", b"i", None),
+        (b"\x00ab==", b"@\x00", b"i", None),
+        (b"ab:==", b":", b"i", None),
+        (b"ab=:=", b":", b"i", None),
+        (b"ab==:", b":", b"i", None),
+        (b"abc=:", b":", b"i\xb7", None),
+        (b"@ab==", b":", b"i", BinAsciiError),
+        (b"ab@==", b":", b"i", BinAsciiError),
+        (b"ab=@=", b":", b"i", BinAsciiError),
+        (b"abc@=", b":", b"i\xb7", BinAsciiError),
+    ],
+)
+@utils.param_simd
+def test_base64_dec_invalid_partial(
+    data: bytes,
+    ignorechars: bytes,
+    no_validation_expected_result: bytes,
+    ignorechars_expected_result: bytes | type | None,
+    simd: int,
+) -> None:
+    utils.unused_args(simd)
+    if ignorechars_expected_result is None:
+        ignorechars_expected_result = no_validation_expected_result
+    with pytest.raises(BinAsciiError):
+        pybase64.b64decode(data, validate=True)
+    with pytest.raises(BinAsciiError):
+        pybase64.b64decode(data, validate=True, ignorechars=b"")
+    ignorechars_no_equal = bytes(set(ignorechars) - set(b"="))
+    ignorechars_has_equal = len(ignorechars_no_equal) != len(ignorechars)
+    if ignorechars_has_equal:
+        with pytest.raises(BinAsciiError):
+            pybase64.b64decode(data, ignorechars=ignorechars_no_equal)
+        if ignorechars_no_equal == b"":
+            with pytest.raises(BinAsciiError):
+                pybase64.b64decode(data, ignorechars=b"@")
+    if isinstance(ignorechars_expected_result, type) and (
+        IGNORECHARS_EQUAL_SUPPORTED or not ignorechars_has_equal
+    ):
+        assert ignorechars_expected_result is BinAsciiError
+        with pytest.raises(BinAsciiError):
+            pybase64.b64decode(data, ignorechars=ignorechars)
+    elif IGNORECHARS_EQUAL_SUPPORTED or not ignorechars_has_equal:
+        assert pybase64.b64decode(data, ignorechars=ignorechars) == ignorechars_expected_result
+    else:
+        with pytest.raises(ValueError, match=r"'=' not supported in ignorechars"):
+            pybase64.b64decode(data, ignorechars=ignorechars)
+    assert pybase64.b64decode(data, validate=False) == no_validation_expected_result
+    assert pybase64.b64decode(data) == no_validation_expected_result

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -21,8 +21,6 @@ if TYPE_CHECKING:
 
 from . import utils
 
-IGNORECHARS_EQUAL_SUPPORTED = utils.has_extension or sys.version_info >= (3, 15)
-
 
 def b64encode_as_string(
     s: Buffer,
@@ -394,6 +392,7 @@ params_invalid_data_novalidate_values = [
     [b"ab", None, BinAsciiError, "Incorrect padding|Non-base64 digit found"],
     [b"abc", None, BinAsciiError, "Incorrect padding|Non-base64 digit found"],
     [b"ab=", None, BinAsciiError, "Incorrect padding|Non-base64 digit found"],
+    [b"ab==c", None, BinAsciiError, "Incorrect padding|Non-base64 digit found|Excess data after"],
 ]
 params_invalid_data_validate_values = [
     [b"\x00\x00\x00\x00", None, BinAsciiError, None],
@@ -790,9 +789,8 @@ def test_ignorechars(dfn: Decode, simd: int) -> None:
         (b"Y==WJj", b"=", b"abc", None),
         (b"YW=Jj", b"=", b"abc", None),
         # excess data
-        (b"ab==c", b"=", b"i", BinAsciiError),
-        (b"ab==cd", b"=", b"i", b"i\xb7\x1d"),
-        (b"abc=d", b"=", b"i\xb7", b"i\xb7\x1d"),
+        (b"ab==cd", b"=", b"i\xb7\x1d", None),
+        (b"abc=d", b"=", b"i\xb7\x1d", None),
         # invalid data
         (b"ab:(){:|:&};:==", b":;(){}|&", b"i", None),
         (b"\nab==", b"\n", b"i", None),
@@ -834,16 +832,11 @@ def test_base64_dec_invalid_partial(
         if ignorechars_no_equal == b"":
             with pytest.raises(BinAsciiError):
                 pybase64.b64decode(data, ignorechars=b"@")
-    if isinstance(ignorechars_expected_result, type) and (
-        IGNORECHARS_EQUAL_SUPPORTED or not ignorechars_has_equal
-    ):
+    if isinstance(ignorechars_expected_result, type) and not ignorechars_has_equal:
         assert ignorechars_expected_result is BinAsciiError
         with pytest.raises(BinAsciiError):
             pybase64.b64decode(data, ignorechars=ignorechars)
-    elif IGNORECHARS_EQUAL_SUPPORTED or not ignorechars_has_equal:
+    elif not ignorechars_has_equal:
         assert pybase64.b64decode(data, ignorechars=ignorechars) == ignorechars_expected_result
-    else:
-        with pytest.raises(ValueError, match=r"'=' not supported in ignorechars"):
-            pybase64.b64decode(data, ignorechars=ignorechars)
     assert pybase64.b64decode(data, validate=False) == no_validation_expected_result
     assert pybase64.b64decode(data) == no_validation_expected_result

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,12 +10,12 @@ import pytest
 
 import pybase64
 
-_has_extension = hasattr(pybase64, "_set_simd_path")
-assert _has_extension or os.environ.get("CIBUILDWHEEL", "0") == "0"
+has_extension = hasattr(pybase64, "_set_simd_path")
+assert has_extension or os.environ.get("CIBUILDWHEEL", "0") == "0"
 
 compile_flags = [0]
 runtime_flags = 0
-if _has_extension:
+if has_extension:
     runtime_flags = pybase64._get_simd_flags_runtime()  # type: ignore[attr-defined]
     flags = pybase64._get_simd_flags_compile()  # type: ignore[attr-defined]
     for i in range(31):
@@ -24,7 +24,7 @@ if _has_extension:
 
 
 def _get_simd_name(simd_id: int) -> str:
-    if _has_extension:
+    if has_extension:
         simd_flag = compile_flags[simd_id]
         simd_name = "C" if simd_flag == 0 else pybase64._get_simd_name(simd_flag)  # type: ignore[attr-defined]
     else:
@@ -43,7 +43,7 @@ param_simd = pytest.mark.parametrize(
 @pytest.fixture
 def simd(request: pytest.FixtureRequest) -> Iterator[int]:
     simd_id = request.param
-    if not _has_extension:
+    if not has_extension:
         assert simd_id == 0
         yield simd_id
         return


### PR DESCRIPTION
fix #976

Python 3.15 should be nearly feature complete with 3.15.0a8 expected today.