### PR TITLE
ci: add ASan job for CPython 3.15

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python_version: ["3.14", "3.15"]
+        python_version: ["3.14", "3.15.0a7"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -17,8 +17,11 @@ permissions:
 
 jobs:
   asan:
-    name: ASan
+    name: ASan CPython ${{ matrix.python_version }}
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python_version: ["3.14", "3.15"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -56,8 +59,8 @@ jobs:
             zlib1g-dev
       - name: Build Python with address sanitizer
         run: |
-          CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.14
-          pyenv global 3.14
+          CONFIGURE_OPTS="--with-address-sanitizer" pyenv install ${{ matrix.python_version }}
+          pyenv global ${{ matrix.python_version }}
       - name: Install dependencies
         run: |
           set -exuo pipefail


### PR DESCRIPTION
CPython 3.15+ uses a different code path than CPython<3.15
Let's check both paths