### PR TITLE
ci: use `-DNDEBUG` for coverage builds

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -122,7 +122,7 @@ def _coverage(session: nox.Session) -> None:
     # make extension mandatory by exporting CIBUILDWHEEL=1
     env = {
         "CIBUILDWHEEL": "1",
-        "CFLAGS": "-O0 -coverage",
+        "CFLAGS": "-O0 -coverage -DNDEBUG",
         "LDFLAGS": "-coverage",
     }
     update_env_macos(session, env)


### PR DESCRIPTION
This disables asserts at compile time as we'd get in release builds.
This removes some uncovered branches.