### PR TITLE
fix: invalid data successfully decoded when using altchars

### DIFF
--- a/src/pybase64/_pybase64.c
+++ b/src/pybase64/_pybase64.c
@@ -1160,12 +1160,16 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         /* not interacting with Python objects from here, release the GIL */
         Py_BEGIN_ALLOW_THREADS
 
-        int const libbase64_simd_flag = state->libbase64_simd_flag;
+        int const b64_flags =  state->libbase64_simd_flag;
+        struct base64_state b64_state;
+
+        base64_stream_decode_init(&b64_state, b64_flags);
+
         while (len > src_slice) {
             size_t dst_len = dst_slice;
 
             translate_fn(src, cache, src_slice, alphabet, &has_bad_char);
-            result = base64_decode(cache, src_slice, dst, &dst_len, libbase64_simd_flag);
+            result = base64_stream_decode(&b64_state, cache, src_slice, dst, &dst_len);
             if (result <= 0) {
                 break;
             }
@@ -1177,7 +1181,10 @@ static PyObject* pybase64_decode_impl(PyObject* self, PyObject* args, PyObject *
         }
         if (result > 0) {
             translate_fn(src, cache, len, alphabet, &has_bad_char);
-            result = base64_decode(cache, len, dst, &out_len, libbase64_simd_flag);
+            result = base64_stream_decode(&b64_state, cache, len, dst, &out_len);
+            if (b64_state.bytes != 0) {
+                result = 0;
+            }
         }
 
         /* restore the GIL */

--- a/tests/test_pybase64.py
+++ b/tests/test_pybase64.py
@@ -1051,3 +1051,19 @@ def test_canonical_check_all(
         assert dfn(vector, altchars=altchars) == expected
         assert dfn(vector, altchars=altchars, validate=True, canonical=True) == expected
         assert dfn(vector, altchars=altchars, canonical=True) == expected
+
+
+@param_decode_functions
+@utils.param_simd
+def test_altchars_chunk_limit(
+    dfn: Decode,
+    simd: int,
+) -> None:
+    utils.unused_args(simd)
+    altchars = b"-_"
+    # valid padding at the end of the first slice
+    vector = b"A" * (16 * 1024 - 2) + b"==" + b"AAAA"
+    with pytest.raises(BinAsciiError, match=r"Non-base64 digit found|Excess data after padding"):
+        dfn(vector, altchars=altchars, validate=True)
+    with pytest.raises(BinAsciiError, match=r"Non-base64 digit found|Excess data after padding"):
+        dfn(vector, altchars=altchars, ignorechars=b"\n")


### PR DESCRIPTION
When a slice used for alphabet translation ends with valid padding, the excess data after padding is not detected.